### PR TITLE
Fix anti-controls

### DIFF
--- a/unitary/alpha/README.md
+++ b/unitary/alpha/README.md
@@ -136,8 +136,6 @@ This will show a mix of FULL and EMPTY states, but both 'h3' and
 
 You can also do anti-controls, such as:
 
-(Note: this doesn't quite work for some reason yet)
-
 ```
 alpha.quantum_if(board['f3']).equals(Square.EMPTY).then(alpha.Flip())(board['f4'])
 print(chess_board.peek([board['f3'], board['f4']], count=100))

--- a/unitary/alpha/quantum_effect_test.py
+++ b/unitary/alpha/quantum_effect_test.py
@@ -46,6 +46,7 @@ def test_anti_control():
     expected_circuit.append(cirq.X(Q0))
     expected_circuit.append(cirq.X(Q0))
     expected_circuit.append(cirq.CNOT(Q0, Q1))
+    expected_circuit.append(cirq.X(Q0))
     assert board.circuit == expected_circuit
 
 


### PR DESCRIPTION
There needs to be an X gate after the control gate to put the
qubit back in the original state.

Also adds some documentation to quantum if/then classes.