### PR TITLE
Add readme to clarify peek() and quantum_if behavior.

### DIFF
--- a/unitary/alpha/README.md
+++ b/unitary/alpha/README.md
@@ -127,9 +127,9 @@ We can also do a quantum if statement that applies an effect
 only if a quantum object is a certain state.  This manifests
 in a "controlled" gate in the quantum world.
 
-Note that a quantum if only applies to quantum effects.  You
+Note that a `quantum_if` only applies to quantum effects.  You
 cannot put classical effects or imperative code as a controlled
-effect of a quantum if.  (In general, classical code, such as
+effect of a `quantum_if()`.  (In general, classical code, such as
 assignments are usually irreversible and thusly incompatible
 with quantum unitary operations without special consideration,
 such as adding ancilla operations, i.e. Stinespring's dilation).

--- a/unitary/alpha/README.md
+++ b/unitary/alpha/README.md
@@ -82,6 +82,10 @@ print('a3:')
 print(chess_board.peek([board['a3']]))
 ```
 
+Note that `peek()` with no arguments defaults to getting a sample
+of all the `QuantumObjects` within the `QuantumWorld`.  By passing
+no arguments, you can essentially get a sample of the whole board.
+
 Note: pop does not quite work yet (as it requires post-selection).
 
 ## Quantum Effects
@@ -122,6 +126,13 @@ and some are FULL.
 We can also do a quantum if statement that applies an effect
 only if a quantum object is a certain state.  This manifests
 in a "controlled" gate in the quantum world.
+
+Note that a quantum if only applies to quantum effects.  You
+cannot put classical effects or imperative code as a controlled
+effect of a quantum if.  (In general, classical code, such as
+assignments are usually irreversible and thusly incompatible
+with quantum unitary operations without special consideration,
+such as adding ancilla operations, i.e. Stinespring's dilation).
 
 For instance,
 


### PR DESCRIPTION
- Add note that peek() with no arguments defaults to sampling
the whole board.
- Add a note that quantum_if effects can only apply to
quantum effects and use the fancy term Stinespring's dilation.