### PR TITLE
Add missing "toc:"

### DIFF
--- a/docs/_toc.yaml
+++ b/docs/_toc.yaml
@@ -1,3 +1,4 @@
+toc:
 - heading: "Quantum Chess"
 - title: "Overview"
   path: /cirq/experiments/unitary/quantum_chess


### PR DESCRIPTION
An included toc file must start with `toc:` as the first line.