### PR TITLE
Fix post-selection and re-use of popped qubits.

### DIFF
--- a/unitary/alpha/quantum_world.py
+++ b/unitary/alpha/quantum_world.py
@@ -125,15 +125,15 @@ class QuantumWorld:
            equal to the count parameter.  Each element will be a list
            of measurement results for each object.
         """
-        if _num_reps is not None:
+        if _num_reps is None:
+            num_reps = self._suggest_num_reps(count)
+        else:
             if _num_reps > 1e6:
                 raise RecursionError(
                     f"Count {count} reached without sufficient results. "
                     "Likely post-selection error"
                 )
             num_reps = _num_reps
-        else:
-            num_reps = self._suggest_num_reps(count)
 
         measure_circuit = self.circuit.copy()
         if objects is None:

--- a/unitary/alpha/quantum_world.py
+++ b/unitary/alpha/quantum_world.py
@@ -84,6 +84,13 @@ class QuantumWorld:
     def force_measurement(
         self, obj: QuantumObject, result: Union[enum.Enum, int]
     ) -> str:
+        """Measures a QuantumObject with a defined outcome.
+
+        This function will move the qubit to an ancilla and set
+        a post-selection criteria on it in order to force it
+        to be a particular result.  A new qubit set to the initial
+        state of the result.
+        """
         count = 0
         ancilla_name = f"ancilla_{obj.name}_{count}"
         while ancilla_name in self.used_object_keys:

--- a/unitary/alpha/quantum_world.py
+++ b/unitary/alpha/quantum_world.py
@@ -32,6 +32,7 @@ class QuantumWorld:
         self.effect_history = []
         self.used_object_keys = set()
         self.sampler = sampler
+        self.ancilla_names = set()
         self.post_selection: Dict[QuantumObject, int] = {}
 
         if objects is not None:
@@ -80,12 +81,32 @@ class QuantumWorld:
             sample_size = 100
         return sample_size
 
+    def force_measurement(
+        self, obj: QuantumObject, result: Union[enum.Enum, int]
+    ) -> str:
+        count = 0
+        ancilla_name = f"ancilla_{obj.name}_{count}"
+        while ancilla_name in self.used_object_keys:
+            count += 1
+            ancilla_name = f"ancilla_{obj.name}_{count}"
+        new_obj = QuantumObject(ancilla_name, result)
+        self.add_object(new_obj)
+        self.ancilla_names.add(ancilla_name)
+        self.circuit = self.circuit.transform_qubits(
+            lambda q: q
+            if q != obj.qubit and q != new_obj.qubit
+            else (new_obj.qubit if q == obj.qubit else obj.qubit)
+        )
+        post_selection = result.value if isinstance(result, enum.Enum) else result
+        self.post_selection[new_obj] = post_selection
+
     def peek(
         self,
         objects: Optional[Sequence[QuantumObject]] = None,
         count: int = 1,
         convert_to_enum: bool = True,
         _existing_list: List[List[Union[enum.Enum, int]]] = None,
+        _num_reps: Optional[int] = None,
     ) -> List[List[Union[enum.Enum, int]]]:
         """Measures the state of the system 'non-destructively'.
 
@@ -97,6 +118,16 @@ class QuantumWorld:
            equal to the count parameter.  Each element will be a list
            of measurement results for each object.
         """
+        if _num_reps is not None:
+            if _num_reps > 1e6:
+                raise RecursionError(
+                    f"Count {count} reached without sufficient results. "
+                    "Likely post-selection error"
+                )
+            num_reps = _num_reps
+        else:
+            num_reps = self._suggest_num_reps(count)
+
         measure_circuit = self.circuit.copy()
         if objects is None:
             objects = self.objects
@@ -104,10 +135,6 @@ class QuantumWorld:
         measure_circuit.append(
             [cirq.measure(p.qubit, key=p.qubit.name) for p in measure_set]
         )
-
-        num_reps = self._suggest_num_reps(count)
-        if _existing_list is not None:
-            num_reps *= 4
         results = self.sampler.run(measure_circuit, repetitions=num_reps)
 
         # Perform post-selection
@@ -121,13 +148,19 @@ class QuantumWorld:
                     break
             if post_selected:
                 rtn_list.append(
-                    [results.measurements[obj.name][rep] for obj in objects]
+                    [
+                        results.measurements[obj.name][rep]
+                        for obj in objects
+                        if obj.name not in self.ancilla_names
+                    ]
                 )
                 if len(rtn_list) == count:
                     break
         if len(rtn_list) < count:
             # We post-selected too much, get more reps
-            return self.peek(objects, count, convert_to_enum, rtn_list)
+            return self.peek(
+                objects, count, convert_to_enum, rtn_list, _num_reps=num_reps * 10
+            )
 
         if convert_to_enum:
             rtn_list = [
@@ -152,7 +185,6 @@ class QuantumWorld:
             objects = self.objects
         results = self.peek(objects, convert_to_enum=convert_to_enum)
         for idx, result in enumerate(results[0]):
-            post_selection = result.value if isinstance(result, enum.Enum) else result
-            self.post_selection[objects[idx]] = post_selection
+            self.force_measurement(objects[idx], result)
 
         return results[0]

--- a/unitary/alpha/quantum_world_test.py
+++ b/unitary/alpha/quantum_world_test.py
@@ -97,6 +97,17 @@ def test_pop():
     assert all(result[1] != popped for result in results)
 
 
+def test_pop_and_reuse():
+    """Tests reusing a popped qubit."""
+    light = alpha.QuantumObject("l1", Light.GREEN)
+    board = alpha.QuantumWorld([light])
+    popped = board.pop([light])[0]
+    assert popped == Light.GREEN
+    alpha.Flip()(light)
+    popped = board.pop([light])[0]
+    assert popped == Light.RED
+
+
 def test_undo():
     light = alpha.QuantumObject("l1", Light.GREEN)
     board = alpha.QuantumWorld([light])
@@ -138,7 +149,11 @@ def test_undo_post_select():
 
 
 def test_pop_not_enough_reps():
-    lights = [alpha.QuantumObject("l" + str(i), Light.RED) for i in range(20)]
+    """Tests forcing a measurement of a rare outcome,
+    so that peek needs to be called recursively to get more
+    occurances.
+    """
+    lights = [alpha.QuantumObject("l" + str(i), Light.RED) for i in range(15)]
     board = alpha.QuantumWorld(lights)
     alpha.Flip()(lights[0])
     alpha.Split()(lights[0], lights[1], lights[2])
@@ -148,14 +163,36 @@ def test_pop_not_enough_reps():
     alpha.Split()(lights[8], lights[9], lights[10])
     alpha.Split()(lights[10], lights[11], lights[12])
     alpha.Split()(lights[12], lights[13], lights[14])
-    alpha.Split()(lights[14], lights[15], lights[16])
 
-    results = board.peek([lights[16]], count=200)
+    results = board.peek([lights[14]], count=20000)
+    assert any(result[0] == Light.GREEN for result in results)
     assert not all(result[0] == Light.GREEN for result in results)
-    board.pop([lights[16]])
+    board.force_measurement(lights[14], Light.GREEN)
 
-    # Force post select to a rare value
-    board.post_selection[lights[16]] = 1
-    results = board.peek([lights[16]], count=200)
+    results = board.peek([lights[14]], count=200)
     assert len(results) == 200
     assert all(result[0] == Light.GREEN for result in results)
+    results = board.peek(count=200)
+    assert all(len(result) == 15 for result in results)
+    assert all(result == [Light.RED] * 14 + [Light.GREEN] for result in results)
+
+
+def test_pop_qubits_twice():
+    """Tests popping qubits twice, so that 2 ancillas are created
+    for each qubit."""
+    lights = [alpha.QuantumObject("l" + str(i), Light.RED) for i in range(3)]
+    board = alpha.QuantumWorld(lights)
+    alpha.Flip()(lights[0])
+    alpha.Split()(lights[0], lights[1], lights[2])
+    result = board.pop()
+    green_on_1 = [Light.RED, Light.GREEN, Light.RED]
+    green_on_2 = [Light.RED, Light.RED, Light.GREEN]
+    assert (result == green_on_1) or (result == green_on_2)
+    alpha.Move()(lights[1], lights[2])
+    result2 = board.pop()
+    peek_results = board.peek(count=200)
+    if result == green_on_1:
+        assert result2 == green_on_2
+    else:
+        assert result2 == green_on_1
+    assert all(peek_result == result2 for peek_result in peek_results)


### PR DESCRIPTION
- This PR fixes post-selection and reuse of qubits.
- Now, after a pop(), the qubit is replaced by a new qubit that is
  initialized to the value of the measurement, and the old qubit
  is moved to an ancilla and post-selected on.
- This PR also includes a force_measurement() function, that can
be used to force a measurement of a particular outcome (for instance,
in replaying a game).

Fixes:#21