### PR TITLE
Update to conform to new cirq.device API.

### DIFF
--- a/unitary/quantum_chess/circuit_transformer.py
+++ b/unitary/quantum_chess/circuit_transformer.py
@@ -47,7 +47,7 @@ class ConnectivityHeuristicCircuitTransformer:
         self.device = device
         self.mapping = None
         self.starting_qubit = self.find_start_qubit(device.qubits)
-        self.qubit_list = device.qubits
+        self.qubit_list = device.metadata.qubit_set
 
     def qubits_within(
         self,


### PR DESCRIPTION
Retrieve device qubits using cirq.device.metadata.qubit_set instead of cirq.device.qubits.