### PR TITLE
Upgrade Quantum Chess to Cirq 1.0

### DIFF
--- a/unitary/quantum_chess/controlled_iswap.py
+++ b/unitary/quantum_chess/controlled_iswap.py
@@ -130,7 +130,7 @@ def controlled_sqrt_iswap(a: cirq.Qid, b: cirq.Qid, c: cirq.Qid):
             cirq.CZ(c, b) ** 0.25,
             cirq.CNOT(a, b),
         ),
-        gateset=cirq.SqrtIswapTargetGateset()
+        gateset=cirq.SqrtIswapTargetGateset(),
     )
 
 
@@ -143,5 +143,5 @@ def controlled_inv_sqrt_iswap(a: cirq.Qid, b: cirq.Qid, c: cirq.Qid):
             cirq.CZ(c, b) ** -0.25,
             cirq.CNOT(a, b),
         ),
-        gateset=cirq.SqrtIswapTargetGateset()
+        gateset=cirq.SqrtIswapTargetGateset(),
     )

--- a/unitary/quantum_chess/controlled_iswap.py
+++ b/unitary/quantum_chess/controlled_iswap.py
@@ -14,7 +14,6 @@
 from typing import Sequence, Union, Optional
 
 import cirq
-from cirq import optimizers
 import cirq_google as cg
 import numpy as np
 from cirq.transformers.analytical_decompositions.two_qubit_to_fsim import (
@@ -124,23 +123,25 @@ def controlled_iswap(
 
 def controlled_sqrt_iswap(a: cirq.Qid, b: cirq.Qid, c: cirq.Qid):
     """Performs (ISWAP(a,b)i**0.5).controlled_by(c)"""
-    return cg.optimized_for_sycamore(
+    return cirq.optimize_for_target_gateset(
         cirq.Circuit(
             cirq.CNOT(a, b),
             cirq.TOFFOLI(c, b, a) ** -0.5,
             cirq.CZ(c, b) ** 0.25,
             cirq.CNOT(a, b),
-        )
+        ),
+        gateset=cirq.SqrtIswapTargetGateset()
     )
 
 
 def controlled_inv_sqrt_iswap(a: cirq.Qid, b: cirq.Qid, c: cirq.Qid):
     """Performs (ISWAP(a,b)i**0.5).controlled_by(c)"""
-    return cg.optimized_for_sycamore(
+    return cirq.optimize_for_target_gateset(
         cirq.Circuit(
             cirq.CNOT(a, b),
             cirq.TOFFOLI(c, b, a) ** 0.5,
             cirq.CZ(c, b) ** -0.25,
             cirq.CNOT(a, b),
-        )
+        ),
+        gateset=cirq.SqrtIswapTargetGateset()
     )

--- a/unitary/quantum_chess/swap_updater.py
+++ b/unitary/quantum_chess/swap_updater.py
@@ -122,6 +122,7 @@ def _swap_to_sqrt_iswap(a, b, turns):
     yield cirq.Z(b) ** (turns / 2 + 0.25)
     yield cirq.CZ.on(a, b) ** (-turns)
 
+
 def generate_decomposed_swap(
     q1: cirq.Qid, q2: cirq.Qid
 ) -> Generator[cirq.Operation, None, None]:

--- a/unitary/quantum_chess/swap_updater.py
+++ b/unitary/quantum_chess/swap_updater.py
@@ -23,7 +23,6 @@ from typing import Callable, Dict, Generator, Iterable, List, Optional, Tuple
 import cirq
 
 import unitary.quantum_chess.mcpe_utils as mcpe
-from cirq_google.optimizers.convert_to_sqrt_iswap import swap_to_sqrt_iswap
 
 
 def _satisfies_adjacency(gate: cirq.Operation) -> bool:
@@ -78,11 +77,56 @@ def _pairwise_shortest_distances(
     return shortest
 
 
+def _near_mod_n(e, t, n, atol=1e-8):
+    return abs((e - t + 1) % n - 1) <= atol
+
+
+def _swap_to_sqrt_iswap(a, b, turns):
+    """Implement the evolution of a hopping term using two sqrt_iswap gates and single qubit gates.
+    Output unitary:
+    [[1, 0,        0,     0],
+     [0, g·c,    -i·g·s,  0],
+     [0, -i·g·s,  g·c,    0],
+     [0,   0,      0,     1]]
+     where c = cos(theta) and s = sin(theta).
+    Args:
+        a: the first qubit
+        b: the second qubit
+        turns: The rotational angle that specifies the gate, where
+            c = cos(π·t/2), s = sin(π·t/2), g = exp(i·π·t/2).
+    Yields:
+        A `cirq.OP_TREE` representing the decomposition.
+    """
+    if _near_mod_n(turns, 1.0, 2):
+        # Decomposition for cirq.SWAP
+        yield cirq.Y(a) ** 0.5
+        yield cirq.Y(b) ** 0.5
+        yield cirq.SQRT_ISWAP(a, b)
+        yield cirq.Y(a) ** -0.5
+        yield cirq.Y(b) ** -0.5
+        yield cirq.SQRT_ISWAP(a, b)
+        yield cirq.X(a) ** -0.5
+        yield cirq.X(b) ** -0.5
+        yield cirq.SQRT_ISWAP(a, b)
+        yield cirq.X(a) ** 0.5
+        yield cirq.X(b) ** 0.5
+        return
+
+    yield cirq.Z(a) ** 1.25
+    yield cirq.Z(b) ** -0.25
+    yield cirq.ISWAP(a, b) ** -0.5
+    yield cirq.Z(a) ** (-turns / 2 + 1)
+    yield cirq.Z(b) ** (turns / 2)
+    yield cirq.ISWAP(a, b) ** -0.5
+    yield cirq.Z(a) ** (turns / 2 - 0.25)
+    yield cirq.Z(b) ** (turns / 2 + 0.25)
+    yield cirq.CZ.on(a, b) ** (-turns)
+
 def generate_decomposed_swap(
     q1: cirq.Qid, q2: cirq.Qid
 ) -> Generator[cirq.Operation, None, None]:
     """Generates a SWAP operation using sqrt-iswap gates."""
-    yield from swap_to_sqrt_iswap(q1, q2, 1.0)
+    yield from _swap_to_sqrt_iswap(q1, q2, 1.0)
 
 
 class SwapUpdater:


### PR DESCRIPTION
- Get rid of references to optimizers
- Copy one function over that was removed in the deprecation process.