### PR TITLE
Fix split/merge slide circuits

### DIFF
--- a/unitary/quantum_chess/quantum_board.py
+++ b/unitary/quantum_chess/quantum_board.py
@@ -1076,7 +1076,7 @@ class CirqBoard:
                 # (1, 0): No qubit in one arm, one qubit in the other. 0 ancilla needed.
                 if len(path_qubits) == 1:
                     self.circuit.append(
-                        qm.merge_slide_zero_one(squbit2, tqubit, squbit, path_qubits[0])
+                        qm.merge_slide_one_zero(squbit, tqubit, squbit2, path_qubits[0])
                     )
                 # (2+, 0): No qubit in one arm, multiple qubits in the other. 1 ancilla needed.
                 else:

--- a/unitary/quantum_chess/quantum_board.py
+++ b/unitary/quantum_chess/quantum_board.py
@@ -1007,11 +1007,13 @@ class CirqBoard:
                 else:
                     path2 = self._create_path_ancilla(path_qubits2)
                     ancilla = self.new_ancilla()
+                    self.circuit.append(cirq.X(path_qubits[0]))
                     self.circuit.append(
-                        qm.split_slide_one_multiple(
+                        qm.split_slide(
                             squbit, tqubit, tqubit2, path_qubits[0], path2, ancilla
                         )
                     )
+                    self.circuit.append(cirq.X(path_qubits[0]))
                     self._clear_path_ancilla(path_qubits2, path2)
                 return 1
             # (2+, 1): one qubit in one arm, multiple qubits in the other. 2 ancillas needed.
@@ -1019,11 +1021,13 @@ class CirqBoard:
                 self.add_entangled(squbit, tqubit, tqubit2)
                 path1 = self._create_path_ancilla(path_qubits)
                 ancilla = self.new_ancilla()
+                self.circuit.append(cirq.X(path_qubits2[0]))
                 self.circuit.append(
-                    qm.split_slide_one_multiple(
-                        squbit, tqubit2, tqubit, path_qubits2[0], path1, ancilla
+                    qm.split_slide(
+                        squbit, tqubit, tqubit2, path1, path_qubits2[0], ancilla
                     )
                 )
+                self.circuit.append(cirq.X(path_qubits2[0]))
                 self._clear_path_ancilla(path_qubits, path1)
                 return 1
             # (2+, 2+): multiple qubits in both arms. 3 ancillas needed.
@@ -1114,11 +1118,13 @@ class CirqBoard:
                 else:
                     path2 = self._create_path_ancilla(path_qubits2)
                     ancilla = self.new_ancilla()
+                    self.circuit.append(cirq.X(path_qubits[0]))
                     self.circuit.append(
-                        qm.merge_slide_one_multiple(
+                        qm.merge_slide(
                             squbit, tqubit, squbit2, path_qubits[0], path2, ancilla
                         )
                     )
+                    self.circuit.append(cirq.X(path_qubits[0]))
                     self._clear_path_ancilla(path_qubits2, path2)
                 return 1
             # (2+, 1): one qubit in one arm, multiple qubits in the other. 2 ancillas needed.
@@ -1126,11 +1132,13 @@ class CirqBoard:
                 self.add_entangled(squbit, squbit2, tqubit)
                 path1 = self._create_path_ancilla(path_qubits)
                 ancilla = self.new_ancilla()
+                self.circuit.append(cirq.X(path_qubits2[0]))
                 self.circuit.append(
-                    qm.merge_slide_one_multiple(
-                        squbit2, tqubit, squbit, path_qubits2[0], path1, ancilla
+                    qm.merge_slide(
+                        squbit, tqubit, squbit2, path1, path_qubits2[0], ancilla
                     )
                 )
+                self.circuit.append(cirq.X(path_qubits2[0]))
                 self._clear_path_ancilla(path_qubits, path1)
                 return 1
             # (2+, 2+): multiple qubits in both arms. 3 ancillas needed.

--- a/unitary/quantum_chess/quantum_board.py
+++ b/unitary/quantum_chess/quantum_board.py
@@ -975,7 +975,7 @@ class CirqBoard:
                 else:
                     path1 = self._create_path_ancilla(path_qubits)
                     self.circuit.append(
-                        qm.split_slide_zero_multiple(squbit, tqubit2, tqubit, path1)
+                        qm.split_slide_multiple_zero(squbit, tqubit, tqubit2, path1)
                     )
                     self._clear_path_ancilla(path_qubits, path1)
                 return 1
@@ -1082,7 +1082,7 @@ class CirqBoard:
                 else:
                     path1 = self._create_path_ancilla(path_qubits)
                     self.circuit.append(
-                        qm.merge_slide_zero_multiple(squbit2, tqubit, squbit, path1)
+                        qm.merge_slide_multiple_zero(squbit, tqubit, squbit2, path1)
                     )
                     self._clear_path_ancilla(path_qubits, path1)
                 return 1

--- a/unitary/quantum_chess/quantum_board.py
+++ b/unitary/quantum_chess/quantum_board.py
@@ -969,7 +969,7 @@ class CirqBoard:
                 # (1, 0): No qubit in one arm, one qubit in the other. 0 ancilla needed.
                 if len(path_qubits) == 1:
                     self.circuit.append(
-                        qm.split_slide_zero_one(squbit, tqubit2, tqubit, path_qubits[0])
+                        qm.split_slide_one_zero(squbit, tqubit, tqubit2, path_qubits[0])
                     )
                 # (2+, 0): No qubit in one arm, multiple qubits in the other. 1 ancilla needed.
                 else:

--- a/unitary/quantum_chess/quantum_board_test.py
+++ b/unitary/quantum_chess/quantum_board_test.py
@@ -344,9 +344,8 @@ def test_blocked_slide_move(board):
         "a1", "d1", move_type=enums.MoveType.SLIDE, move_variant=enums.MoveVariant.BASIC
     )
     b.do_move(m)
-    samples = b.sample(10)
     expected = u.squares_to_bitboard(["a1", "b1"])
-    assert all(sample == expected for sample in samples)
+    assert_samples_in(b, [expected])
 
 
 @pytest.mark.parametrize("board", ALL_CIRQ_BOARDS)
@@ -381,9 +380,8 @@ def test_blocked_slide_blocked(board):
         "f5", "d5", move_type=enums.MoveType.SLIDE, move_variant=enums.MoveVariant.BASIC
     )
     b.do_move(m)
-    samples = b.sample(100)
     expected = u.squares_to_bitboard(["e5", "f5"])
-    assert all(sample == expected for sample in samples)
+    assert_samples_in(b, [expected])
 
 
 def test_blocked_slide_capture_through():
@@ -549,13 +547,14 @@ def test_split_slide_zero_one():
     assert b.perform_moves(
         "d3^c3d1:SPLIT_SLIDE:BASIC",
         "a1^a4f1:SPLIT_SLIDE:BASIC",
+        "f1a4^f4:MERGE_SLIDE:BASIC",
     )
     assert_sample_distribution(
         b,
         {
-            u.squares_to_bitboard(["d1", "a4"]): 1 / 2,
-            u.squares_to_bitboard(["c3", "f1"]): 1 / 4,
-            u.squares_to_bitboard(["c3", "a4"]): 1 / 4,
+            u.squares_to_bitboard(["c3", "f4"]): 1 / 2,
+            u.squares_to_bitboard(["d1", "f4"]): 1 / 4,
+            u.squares_to_bitboard(["d1", "a4"]): 1 / 4,
         },
     )
 

--- a/unitary/quantum_chess/quantum_moves.py
+++ b/unitary/quantum_chess/quantum_moves.py
@@ -255,23 +255,6 @@ def split_slide_one_one_diff_qubits(
     yield cirq.X(path_qubit1)
 
 
-def split_slide_one_multiple(
-    squbit, tqubit_one, tqubit_multiple, path_qubit, path_ancilla, ancilla
-):
-    """Performs a split slide from squbit to two target qubits. Only one qubit
-    (i.e. path_qubit) is in the way from squbit to tqubit_one, while multiple
-    qubits (whose corresponding path ancilla is path_ancilla) are in the way
-    from squbit to tqubit_multiple.
-
-    path_qubit, path_ancilla, and one more ancilla qubit are needed as control.
-    """
-    yield cirq.X(path_qubit)
-    yield split_slide(
-        squbit, tqubit_one, tqubit_multiple, path_qubit, path_ancilla, ancilla
-    )
-    yield cirq.X(path_qubit)
-
-
 def merge_slide(squbit, tqubit, squbit2, path1, path2, ancilla):
     """Performs a merge slide from two source qubits to tqubit.
 
@@ -399,23 +382,6 @@ def merge_slide_one_one_diff_qubits(
     yield merge_slide(squbit, tqubit, squbit2, path_qubit1, path_qubit2, ancilla)
     yield cirq.X(path_qubit2)
     yield cirq.X(path_qubit1)
-
-
-def merge_slide_one_multiple(
-    squbit_one, tqubit, squbit_multiple, path_qubit, path_ancilla, ancilla
-):
-    """Perform a merge slide from two source qubits to tqubit. Only one qubit
-    (i.e. path_qubit) is in the way from squbit_one to tqubit, while multiple
-    qubits (whose corresponding path ancilla is path_ancilla) are in the way
-    from squbit_multiple to tqubit.
-
-    path_qubit, path_ancilla, and one more ancilla qubit are needed as control.
-    """
-    yield cirq.X(path_qubit)
-    yield merge_slide(
-        squbit_one, tqubit, squbit_multiple, path_qubit, path_ancilla, ancilla
-    )
-    yield cirq.X(path_qubit)
 
 
 def en_passant_basic(

--- a/unitary/quantum_chess/quantum_moves.py
+++ b/unitary/quantum_chess/quantum_moves.py
@@ -168,9 +168,9 @@ def split_slide(squbit, tqubit, tqubit2, path1, path2, ancilla):
     yield cirq.X(ancilla).controlled_by(path2, path1)
 
 
-def split_slide_zero_one(squbit, tqubit_clear, tqubit, path_qubit):
+def split_slide_one_zero(squbit, tqubit, tqubit2, path_qubit):
     """Performs a split slide from squbit to two target qubits.
-    The path from squbit to tqubit_clear is clear.
+    The path from squbit to tqubit2 is clear.
 
     path_qubit is the only qubit in the path from squbit to tqubit,
     and it's used as control.
@@ -179,10 +179,23 @@ def split_slide_zero_one(squbit, tqubit_clear, tqubit, path_qubit):
     yield (cirq.ISWAP(squbit, tqubit) ** 0.5).controlled_by(path_qubit)
     yield cirq.X(path_qubit)
     # Note that the following steps are equivalent to
-    # ISWAP(squbit, tqubit_clear).controlled_by(path_qubit)
-    # ISWAP(squbit, tqubit_clear).anti_controlled_by(path_qubit)
-    yield cirq.ISWAP(squbit, tqubit_clear) ** 0.5
-    yield cirq.ISWAP(squbit, tqubit_clear) ** 0.5
+    # ISWAP(squbit, tqubit2).controlled_by(path_qubit)
+    # ISWAP(squbit, tqubit2).anti_controlled_by(path_qubit)
+    yield cirq.ISWAP(squbit, tqubit2)
+
+
+def split_slide_zero_one(squbit, tqubit, tqubit2, path_qubit):
+    """Performs a split slide from squbit to two target qubits.
+    The path from squbit to tqubit is clear.
+
+    path_qubit is the only qubit in the path from squbit to tqubit2,
+    and it's used as control.
+    """
+    yield cirq.ISWAP(squbit, tqubit) ** 0.5
+    yield (cirq.ISWAP(squbit, tqubit) ** 0.5).controlled_by(path_qubit)
+    yield cirq.X(path_qubit)
+    yield cirq.ISWAP(squbit, tqubit2).controlled_by(path_qubit)
+    yield cirq.X(path_qubit)
 
 
 def split_slide_zero_multiple(squbit, tqubit_clear, tqubit, path_ancilla):

--- a/unitary/quantum_chess/quantum_moves.py
+++ b/unitary/quantum_chess/quantum_moves.py
@@ -294,22 +294,37 @@ def merge_slide(squbit, tqubit, squbit2, path1, path2, ancilla):
     yield cirq.X(ancilla).controlled_by(path1, path2)
 
 
-def merge_slide_zero_one(squbit_clear, tqubit, squbit, path_qubit):
+def merge_slide_zero_one(squbit, tqubit, squbit2, path_qubit):
     """Performs a merge slide from two source qubits to tqubit.
-    The path from squbit_clear to tqubit is clear.
+    The path from squbit to tqubit is clear.
+
+    path_qubit is the only qubit in the path from squbit2 to tqubit,
+    and it's used as control.
+    """
+    # Note that the following unconditional ISWAPs are equivalent to
+    # (ISWAP(squbit, tqubit) ** -1).controlled_by(path_qubit)
+    # (ISWAP(squbit, tqubit) ** -1).anti_controlled_by(path_qubit)
+    yield cirq.ISWAP(squbit, tqubit) ** -0.5
+    yield cirq.ISWAP(squbit, tqubit) ** -0.5
+
+    yield cirq.X(path_qubit)
+    yield (cirq.ISWAP(squbit2, tqubit) ** -0.5).controlled_by(path_qubit)
+    yield cirq.X(path_qubit)
+
+
+def merge_slide_one_zero(squbit, tqubit, squbit2, path_qubit):
+    """Performs a merge slide from two source qubits to tqubit.
+    The path from squbit2 to tqubit is clear.
 
     path_qubit is the only qubit in the path from squbit to tqubit,
     and it's used as control.
     """
-    # Note that the following unconditional ISWAPs are equivalent to
-    # (ISWAP(squbit_clear, tqubit) ** -1).controlled_by(path_qubit)
-    # (ISWAP(squbit_clear, tqubit) ** -1).anti_controlled_by(path_qubit)
-    yield cirq.ISWAP(squbit_clear, tqubit) ** -0.5
-    yield cirq.ISWAP(squbit_clear, tqubit) ** -0.5
+    yield cirq.X(path_qubit)
+    yield (cirq.ISWAP(squbit, tqubit) ** -1).controlled_by(path_qubit)
+    yield cirq.X(path_qubit)
 
-    yield cirq.X(path_qubit)
-    yield (cirq.ISWAP(squbit, tqubit) ** -0.5).controlled_by(path_qubit)
-    yield cirq.X(path_qubit)
+    yield (cirq.ISWAP(squbit2, tqubit) ** -0.5)
+    yield (cirq.ISWAP(squbit2, tqubit) ** -0.5).controlled_by(path_qubit)
 
 
 def merge_slide_zero_multiple(squbit_clear, tqubit, squbit, path_ancilla):

--- a/unitary/quantum_chess/quantum_moves.py
+++ b/unitary/quantum_chess/quantum_moves.py
@@ -184,6 +184,18 @@ def split_slide_one_zero(squbit, tqubit, tqubit2, path_qubit):
     yield cirq.ISWAP(squbit, tqubit2)
 
 
+# Same as split_slide_one_zero except path qubit is inverted
+def split_slide_multiple_zero(squbit, tqubit, tqubit2, path_ancilla):
+    """Performs a split slide from squbit to two target qubits.
+    The path from squbit to tqubit2 is clear.
+
+    Multiple qubits are in the path from squbit to tqubit. Its corresponding
+    path ancilla path_ancilla is needed as control.
+    """
+    yield (cirq.ISWAP(squbit, tqubit) ** 0.5).controlled_by(path_ancilla)
+    yield cirq.ISWAP(squbit, tqubit2)
+
+
 def split_slide_zero_one(squbit, tqubit, tqubit2, path_qubit):
     """Performs a split slide from squbit to two target qubits.
     The path from squbit to tqubit is clear.
@@ -198,19 +210,19 @@ def split_slide_zero_one(squbit, tqubit, tqubit2, path_qubit):
     yield cirq.X(path_qubit)
 
 
-def split_slide_zero_multiple(squbit, tqubit_clear, tqubit, path_ancilla):
+# Same as split_slide_zero_one but with the path qubit inverted.
+def split_slide_zero_multiple(squbit, tqubit, tqubit2, path_ancilla):
     """Performs a split slide from squbit to two target qubits.
-    The path from squbit to tqubit_clear is clear.
+    The path from squbit to tqubit is clear.
 
-    Multiple qubits are in the path from squbit to tqubit. Its corresponding
+    Multiple qubits are in the path from squbit to tqubit2. Its corresponding
     path ancilla path_ancilla is needed as control.
     """
+    yield cirq.ISWAP(squbit, tqubit) ** 0.5
+    yield cirq.X(path_ancilla)
     yield (cirq.ISWAP(squbit, tqubit) ** 0.5).controlled_by(path_ancilla)
-    # Note that the following steps are equivalent to
-    # ISWAP(squbit, tqubit_clear).controlled_by(path_ancilla)
-    # ISWAP(squbit, tqubit_clear).anti_controlled_by(path_ancilla)
-    yield cirq.ISWAP(squbit, tqubit_clear) ** 0.5
-    yield cirq.ISWAP(squbit, tqubit_clear) ** 0.5
+    yield cirq.X(path_ancilla)
+    yield cirq.ISWAP(squbit, tqubit2).controlled_by(path_ancilla)
 
 
 def split_slide_one_one_same_qubit(squbit, tqubit, tqubit2, path_qubit):
@@ -327,20 +339,36 @@ def merge_slide_one_zero(squbit, tqubit, squbit2, path_qubit):
     yield (cirq.ISWAP(squbit2, tqubit) ** -0.5).controlled_by(path_qubit)
 
 
-def merge_slide_zero_multiple(squbit_clear, tqubit, squbit, path_ancilla):
+# Same as merge_slide_zero_one but with the path qubit inverted.
+def merge_slide_zero_multiple(squbit, tqubit, squbit2, path_ancilla):
     """Performs a merge slide from two source qubits to tqubit.
-    The path from squbit_clear to tqubit is clear.
+    The path from squbit to tqubit is clear.
+
+    Multiple qubits are in the path from squbit2 to tqubit. Its corresponding
+    path ancilla path_ancilla is needed as control.
+    """
+    # Note that the following unconditional ISWAPs are equivalent to
+    # (ISWAP(squbit, tqubit) ** -1).controlled_by(path_ancilla)
+    # (ISWAP(squbit, tqubit) ** -1).anti_controlled_by(path_ancilla)
+    yield cirq.ISWAP(squbit, tqubit) ** -0.5
+    yield cirq.ISWAP(squbit, tqubit) ** -0.5
+
+    yield (cirq.ISWAP(squbit2, tqubit) ** -0.5).controlled_by(path_ancilla)
+
+
+# Same as merge_slide_one_zero but with the path qubit inverted.
+def merge_slide_multiple_zero(squbit, tqubit, squbit2, path_ancilla):
+    """Performs a merge slide from two source qubits to tqubit.
+    The path from squbit2 to tqubit is clear.
 
     Multiple qubits are in the path from squbit to tqubit. Its corresponding
     path ancilla path_ancilla is needed as control.
     """
-    # Note that the following unconditional ISWAPs are equivalent to
-    # (ISWAP(squbit_clear, tqubit) ** -1).controlled_by(path_ancilla)
-    # (ISWAP(squbit_clear, tqubit) ** -1).anti_controlled_by(path_ancilla)
-    yield cirq.ISWAP(squbit_clear, tqubit) ** -0.5
-    yield cirq.ISWAP(squbit_clear, tqubit) ** -0.5
-
-    yield (cirq.ISWAP(squbit, tqubit) ** -0.5).controlled_by(path_ancilla)
+    yield (cirq.ISWAP(squbit, tqubit) ** -1).controlled_by(path_ancilla)
+    yield (cirq.ISWAP(squbit2, tqubit) ** -0.5)
+    yield cirq.X(path_ancilla)
+    yield (cirq.ISWAP(squbit2, tqubit) ** -0.5).controlled_by(path_ancilla)
+    yield cirq.X(path_ancilla)
 
 
 def merge_slide_one_one_same_qubit(squbit, tqubit, squbit2, path_qubit):


### PR DESCRIPTION
In some cases the slide target qubits or the merge source qubits were swapped. This doesn't work because the circuits aren't symmetrical. So it's necessary to add additional circuits for the mirror-image versions.