### PR TITLE
Classically keep track of non-empty holes for the fox in the hole example

### DIFF
--- a/unitary/examples/fox_in_a_hole/fox_in_a_hole.py
+++ b/unitary/examples/fox_in_a_hole/fox_in_a_hole.py
@@ -192,8 +192,7 @@ class QuantumGame(Game):
     def take_random_move(self) -> str:
         """Applies a random move on the current state. Gives back the move in string format."""
         # Pick a random non-empty hole
-        non_empty_holes = np.where(self.empty_holes == 0)
-
+        non_empty_holes = np.where(self.empty_holes == 0)[0]
         index = self.rng.integers(low=0, high=len(non_empty_holes))
         source = non_empty_holes[index]
 
@@ -252,6 +251,11 @@ class QuantumGame(Game):
             # The targets are now definitely non-empty
             self.empty_holes[source-1] = 0
             self.empty_holes[source+1] = 0
+
+            # Check if source is now empty (peek at it)
+            result = self.state[0].peek([self.state[1][source]], count=10, convert_to_enum=False)
+            self.empty_holes[source] = 0 if np.any(result) else 1
+
         return move_str
 
 


### PR DESCRIPTION
As the game progresses, it becomes increasingly slow (up to several seconds for games of 8 moves) to play. Partly, this is because of the game re-computing the probability distribution for the state at every move in order to determine a 'source' from which the fox can move. 

This PR will circumvent that by keeping track of the empty holes classically.

**Important**: The real issue is an underlying one in the way this sampling happens. After pop()'s, ancillary qubits are added to the quantum world, which are subsequently also being sampled (I think?). That may not be the desired behaviour. 