### PR TITLE
Sparse state vector simulator

### DIFF
--- a/dev_tools/write-ci-requirements.py
+++ b/dev_tools/write-ci-requirements.py
@@ -8,9 +8,8 @@ REPO_DIR = pathlib.Path(__file__).parent.parent.resolve()
 print('Repo dir:', REPO_DIR)
 
 CIRQ_VERSIONS = {
-    'previous': '==0.13.0',
-    'current': '==0.14.0',
-    'next': '>=0.15.0.dev',
+    'current': '==0.15.0',
+    'next': '>=1.0.0',
 }
 """Give names to relative Cirq versions so CI can have consistent names while versions
 get incremented."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-cirq-core>=0.14.0
-cirq-google>=0.14.0
+cirq-core>=0.15.0
+cirq-google>=0.15.0
 # When changing Cirq requirements be sure to update dev_tools/write-ci-requirements.py
 
 seaborn

--- a/unitary/alpha/__init__.py
+++ b/unitary/alpha/__init__.py
@@ -41,3 +41,7 @@ from unitary.alpha.qudit_effects import (
 from unitary.alpha.quantum_object import (
     QuantumObject,
 )
+
+from unitary.alpha.sparse_vector_simulator import (
+    SparseSimulator,
+)

--- a/unitary/alpha/quantum_effect_test.py
+++ b/unitary/alpha/quantum_effect_test.py
@@ -17,13 +17,15 @@ import pytest
 import cirq
 
 import unitary.alpha as alpha
+from unitary.alpha.sparse_vector_simulator import SparseSimulator
 
 Q0 = cirq.NamedQubit("q0")
 Q1 = cirq.NamedQubit("q1")
 
 
-def test_quantum_if():
-    board = alpha.QuantumWorld()
+@pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
+def test_quantum_if(simulator):
+    board = alpha.QuantumWorld(sampler=simulator())
     piece = alpha.QuantumObject("q0", 1)
     piece2 = alpha.QuantumObject("q1", 0)
     board.add_object(piece)
@@ -42,8 +44,9 @@ def test_quantum_if():
     assert (result[1] == 1 for result in results)
 
 
-def test_anti_control():
-    board = alpha.QuantumWorld()
+@pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
+def test_anti_control(simulator):
+    board = alpha.QuantumWorld(sampler=simulator())
     piece = alpha.QuantumObject("q0", 0)
     piece2 = alpha.QuantumObject("q1", 0)
     board.add_object(piece)

--- a/unitary/alpha/quantum_object_test.py
+++ b/unitary/alpha/quantum_object_test.py
@@ -18,11 +18,13 @@ import pytest
 import cirq
 
 import unitary.alpha as alpha
+from unitary.alpha.sparse_vector_simulator import SparseSimulator
 
 
-def test_negation():
+@pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
+def test_negation(simulator):
     piece = alpha.QuantumObject("t", 0)
-    board = alpha.QuantumWorld(piece)
+    board = alpha.QuantumWorld(piece, sampler=simulator())
     assert board.peek() == [[0]]
     -piece
     assert board.peek() == [[1]]
@@ -32,10 +34,11 @@ def test_negation():
     assert board.peek() == [[1]]
 
 
-def test_add_world_after_state_change():
+@pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
+def test_add_world_after_state_change(simulator):
     piece = alpha.QuantumObject("t", 0)
     piece += 1
-    board = alpha.QuantumWorld(piece)
+    board = alpha.QuantumWorld(piece, sampler=simulator())
     assert board.peek() == [[1]]
 
 

--- a/unitary/alpha/quantum_world_test.py
+++ b/unitary/alpha/quantum_world_test.py
@@ -225,6 +225,17 @@ def test_combine_overlapping_worlds():
         world2.combine_with(world1)
 
 
+def test_combine_incompatibly_sparse_worlds():
+    l1 = alpha.QuantumObject("l1", Light.GREEN)
+    world1 = alpha.QuantumWorld([l1], sampler=cirq.Simulator())
+    l2 = alpha.QuantumObject("l2", StopLight.YELLOW)
+    world2 = alpha.QuantumWorld([l2], sampler=alpha.SparseSimulator())
+    with pytest.raises(ValueError, match="sparse"):
+        world1.combine_with(world2)
+    with pytest.raises(ValueError, match="sparse"):
+        world2.combine_with(world1)
+
+
 def test_combine_worlds():
     l1 = alpha.QuantumObject("l1", Light.GREEN)
     l2 = alpha.QuantumObject("l2", Light.RED)

--- a/unitary/alpha/quantum_world_test.py
+++ b/unitary/alpha/quantum_world_test.py
@@ -15,6 +15,8 @@
 import enum
 import pytest
 
+import cirq
+
 import unitary.alpha as alpha
 
 
@@ -36,9 +38,10 @@ def test_duplicate_objects():
         board.add_object(alpha.QuantumObject("test", Light.RED))
 
 
-def test_one_qubit():
+@pytest.mark.parametrize("simulator", [cirq.Simulator, alpha.SparseSimulator])
+def test_one_qubit(simulator):
     light = alpha.QuantumObject("test", Light.GREEN)
-    board = alpha.QuantumWorld([light])
+    board = alpha.QuantumWorld([light], sampler=simulator())
     assert board.peek() == [[Light.GREEN]]
     assert board.peek([light], count=2) == [[Light.GREEN], [Light.GREEN]]
     light = alpha.QuantumObject("test", 1)
@@ -48,10 +51,11 @@ def test_one_qubit():
     assert board.pop() == [1]
 
 
-def test_two_qubits():
+@pytest.mark.parametrize("simulator", [cirq.Simulator, alpha.SparseSimulator])
+def test_two_qubits(simulator):
     light = alpha.QuantumObject("green", Light.GREEN)
     light2 = alpha.QuantumObject("red", Light.RED)
-    board = alpha.QuantumWorld([light, light2])
+    board = alpha.QuantumWorld([light, light2], sampler=simulator())
     assert board.peek() == [[Light.GREEN, Light.RED]]
     assert board.peek(convert_to_enum=False) == [[1, 0]]
     assert board.peek([light], count=2) == [[Light.GREEN], [Light.GREEN]]
@@ -80,11 +84,12 @@ def test_two_qutrits():
     assert str(board.circuit) == expected
 
 
-def test_pop():
+@pytest.mark.parametrize("simulator", [cirq.Simulator, alpha.SparseSimulator])
+def test_pop(simulator):
     light = alpha.QuantumObject("l1", Light.GREEN)
     light2 = alpha.QuantumObject("l2", Light.RED)
     light3 = alpha.QuantumObject("l3", Light.RED)
-    board = alpha.QuantumWorld([light, light2, light3])
+    board = alpha.QuantumWorld([light, light2, light3], sampler=simulator())
     alpha.Split()(light, light2, light3)
     results = board.peek([light2, light3], count=200)
     assert all(result[0] != result[1] for result in results)
@@ -97,10 +102,11 @@ def test_pop():
     assert all(result[1] != popped for result in results)
 
 
-def test_pop_and_reuse():
+@pytest.mark.parametrize("simulator", [cirq.Simulator, alpha.SparseSimulator])
+def test_pop_and_reuse(simulator):
     """Tests reusing a popped qubit."""
     light = alpha.QuantumObject("l1", Light.GREEN)
-    board = alpha.QuantumWorld([light])
+    board = alpha.QuantumWorld([light], sampler=simulator())
     popped = board.pop([light])[0]
     assert popped == Light.GREEN
     alpha.Flip()(light)
@@ -108,9 +114,10 @@ def test_pop_and_reuse():
     assert popped == Light.RED
 
 
-def test_undo():
+@pytest.mark.parametrize("simulator", [cirq.Simulator, alpha.SparseSimulator])
+def test_undo(simulator):
     light = alpha.QuantumObject("l1", Light.GREEN)
-    board = alpha.QuantumWorld([light])
+    board = alpha.QuantumWorld([light], sampler=simulator())
     alpha.Flip()(light)
     results = board.peek([light], count=200)
     assert all(result[0] == Light.RED for result in results)
@@ -125,11 +132,12 @@ def test_undo_no_effects():
         board.undo_last_effect()
 
 
-def test_undo_post_select():
+@pytest.mark.parametrize("simulator", [cirq.Simulator, alpha.SparseSimulator])
+def test_undo_post_select(simulator):
     light = alpha.QuantumObject("l1", Light.GREEN)
     light2 = alpha.QuantumObject("l2", Light.RED)
     light3 = alpha.QuantumObject("l3", Light.RED)
-    board = alpha.QuantumWorld([light, light2, light3])
+    board = alpha.QuantumWorld([light, light2, light3], sampler=simulator())
     alpha.Split()(light, light2, light3)
 
     # After split, should be fifty-fifty
@@ -154,13 +162,14 @@ def test_undo_post_select():
     assert not all(result[0] == Light.GREEN for result in results)
 
 
-def test_pop_not_enough_reps():
+@pytest.mark.parametrize("simulator", [cirq.Simulator, alpha.SparseSimulator])
+def test_pop_not_enough_reps(simulator):
     """Tests forcing a measurement of a rare outcome,
     so that peek needs to be called recursively to get more
     occurances.
     """
     lights = [alpha.QuantumObject("l" + str(i), Light.RED) for i in range(15)]
-    board = alpha.QuantumWorld(lights)
+    board = alpha.QuantumWorld(lights, sampler=simulator())
     alpha.Flip()(lights[0])
     alpha.Split()(lights[0], lights[1], lights[2])
     alpha.Split()(lights[2], lights[3], lights[4])
@@ -183,11 +192,12 @@ def test_pop_not_enough_reps():
     assert all(result == [Light.RED] * 14 + [Light.GREEN] for result in results)
 
 
-def test_pop_qubits_twice():
+@pytest.mark.parametrize("simulator", [cirq.Simulator, alpha.SparseSimulator])
+def test_pop_qubits_twice(simulator):
     """Tests popping qubits twice, so that 2 ancillas are created
     for each qubit."""
     lights = [alpha.QuantumObject("l" + str(i), Light.RED) for i in range(3)]
-    board = alpha.QuantumWorld(lights)
+    board = alpha.QuantumWorld(lights, sampler=simulator())
     alpha.Flip()(lights[0])
     alpha.Split()(lights[0], lights[1], lights[2])
     result = board.pop()
@@ -236,9 +246,10 @@ def test_combine_worlds():
     assert all(actual == expected for actual in results)
 
 
-def test_get_histogram_and_get_probabilities_one_binary_qobject():
+@pytest.mark.parametrize("simulator", [cirq.Simulator, alpha.SparseSimulator])
+def test_get_histogram_and_get_probabilities_one_binary_qobject(simulator):
     l1 = alpha.QuantumObject("l1", Light.GREEN)
-    world = alpha.QuantumWorld([l1])
+    world = alpha.QuantumWorld([l1], sampler=simulator())
     histogram = world.get_histogram()
     assert histogram == [{0: 0, 1: 100}]
     probs = world.get_probabilities()

--- a/unitary/alpha/qubit_effects_test.py
+++ b/unitary/alpha/qubit_effects_test.py
@@ -13,29 +13,35 @@
 # limitations under the License.
 #
 
+import pytest
+
 import cirq
 
 import unitary.alpha as alpha
+from unitary.alpha.sparse_vector_simulator import SparseSimulator
 
 
-def test_flip():
-    board = alpha.QuantumWorld()
+@pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
+def test_flip(simulator):
+    board = alpha.QuantumWorld(sampler=simulator())
     piece = alpha.QuantumObject("t", 0)
     board.add_object(piece)
     alpha.Flip()(piece)
     assert board.circuit == cirq.Circuit(cirq.X(cirq.NamedQubit("t")))
 
 
-def test_superposition():
-    board = alpha.QuantumWorld()
+@pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
+def test_superposition(simulator):
+    board = alpha.QuantumWorld(sampler=simulator())
     piece = alpha.QuantumObject("t", 0)
     board.add_object(piece)
     alpha.Superposition()(piece)
     assert board.circuit == cirq.Circuit(cirq.H(cirq.NamedQubit("t")))
 
 
-def test_move():
-    board = alpha.QuantumWorld()
+@pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
+def test_move(simulator):
+    board = alpha.QuantumWorld(sampler=simulator())
     piece1 = alpha.QuantumObject("a", 1)
     piece2 = alpha.QuantumObject("b", 0)
     board.add_object(piece1)
@@ -53,8 +59,9 @@ def test_move():
     assert all(result == [0, 1] for result in results)
 
 
-def test_phased_move():
-    board = alpha.QuantumWorld()
+@pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
+def test_phased_move(simulator):
+    board = alpha.QuantumWorld(sampler=simulator())
     piece1 = alpha.QuantumObject("a", 1)
     piece2 = alpha.QuantumObject("b", 0)
     board.add_object(piece1)
@@ -72,8 +79,9 @@ def test_phased_move():
     assert all(result == [0, 1] for result in results)
 
 
-def test_split():
-    board = alpha.QuantumWorld()
+@pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
+def test_split(simulator):
+    board = alpha.QuantumWorld(sampler=simulator())
     piece1 = alpha.QuantumObject("a", 1)
     piece2 = alpha.QuantumObject("b", 0)
     piece3 = alpha.QuantumObject("c", 0)
@@ -92,8 +100,9 @@ def test_split():
     assert board.circuit == expected_circuit
 
 
-def test_phased_split():
-    board = alpha.QuantumWorld()
+@pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
+def test_phased_split(simulator):
+    board = alpha.QuantumWorld(sampler=simulator())
     piece1 = alpha.QuantumObject("a", 1)
     piece2 = alpha.QuantumObject("b", 0)
     piece3 = alpha.QuantumObject("c", 0)

--- a/unitary/alpha/sparse_vector_simulator.py
+++ b/unitary/alpha/sparse_vector_simulator.py
@@ -94,7 +94,9 @@ class SparseSimulationState(cirq.SimulationState):
         assert value in (0, 1)
         mask = 1 << self.qubit_map[qubit]
         value *= mask
-        nonzero_indices = np.nonzero(self._states & mask == value)
+        (nonzero_indices,) = np.nonzero(self._states & mask == value)
+        if len(nonzero_indices) == 0:
+            raise InvalidPostSelectionError(f"No states where {qubit} equals {value}")
         self._states = self._states[nonzero_indices]
         self._amplitudes = self._amplitudes[nonzero_indices]
         self._amplitudes /= np.linalg.norm(self._amplitudes)
@@ -143,6 +145,10 @@ class PostSelectOperation(cirq.Operation):
 
     def with_qubits(self, new_qubit):
         return PostSelectOperation(new_qubit, self.value)
+
+
+class InvalidPostSelectionError(Exception):
+    """When a qubit state with zero amplitude is post-selected for."""
 
 
 class SparseSimulatorStep(cirq.StepResultBase):

--- a/unitary/alpha/sparse_vector_simulator.py
+++ b/unitary/alpha/sparse_vector_simulator.py
@@ -1,0 +1,121 @@
+"""Noiseless simulator using a sparse state vector.
+
+Just enough features to support Unitary are implemented.
+
+Does not work with 3+-state qudits. TODO: integrate with qutrit-to-qubit conversion
+when that is available.
+"""
+import cirq
+import numpy as np
+
+
+# TODO: Is this a good number?
+EPSILON = 1e-14
+
+
+class SparseSimulationState(cirq.SimulationState):
+    """Implements sparse state vector evolution and sampling.
+
+    Uses object arrays to represent states so that circuits with more than 64
+    qubits work.
+    """
+
+    def __init__(self, qubits):
+        super().__init__(qubits=qubits, state=None)
+        self._states = np.array([0], dtype=object)
+        self._amplitudes = np.array([1], dtype=np.complex128)
+
+    def copy(self):
+        raise NotImplementedError
+
+    def _act_on_fallback_(self, action, qubits, allow_decompose):
+        if action.gate is cirq.X:
+            self._states ^= 1 << self.qubit_map[qubits[0]]
+        else:
+            dst_rows = np.zeros(len(self._states), dtype=int)
+            reverse_affected = np.zeros(1, dtype=object)
+            mask = ~0
+            for dst_bit, qubit in enumerate(qubits[::-1]):
+                src_bit = self.qubit_map[qubit]
+                bit = np.array((self._states >> src_bit) & 1, dtype=int)
+                dst_rows |= bit << dst_bit
+                reverse_affected = np.concatenate(
+                    (reverse_affected, reverse_affected | 1 << src_bit)
+                )
+                mask ^= 1 << src_bit
+            self._states &= mask
+            unique_unaffected, dst_cols = np.unique(self._states, return_inverse=True)
+            partitioned_state = np.zeros(
+                (1 << len(qubits), len(unique_unaffected)), np.complex128
+            )
+            partitioned_state[dst_rows, dst_cols] = self._amplitudes
+            np.matmul(cirq.unitary(action), partitioned_state, out=partitioned_state)
+            nz_rows, nz_cols = np.nonzero(abs(partitioned_state) > EPSILON)
+            self._states = reverse_affected[nz_rows] | unique_unaffected[nz_cols]
+            self._amplitudes = partitioned_state[nz_rows, nz_cols]
+        return True
+
+    def _perform_measurement(self, qubits):
+        raise NotImplementedError
+
+    # abstract method of OperationTarget
+    def sample(self, qubits, repetitions, prng):
+        probs = abs(self._amplitudes) ** 2
+        samples = prng.choice(self._states, size=repetitions, p=probs)
+        out = np.empty((repetitions, len(qubits)), dtype=np.uint8)
+        for j, q in enumerate(qubits):
+            out[:, j] = (samples >> self.qubit_map[q]) & 1
+        return out
+
+    def post_select(self, qubit, value):
+        assert value in (0, 1)
+        mask = 1 << self.qubit_map[qubit]
+        value *= mask
+        nonzero_indices = np.nonzero(self._states & mask == value)
+        self._states = self._states[nonzero_indices]
+        self._amplitudes = self._amplitudes[nonzero_indices]
+        self._amplitudes /= np.linalg.norm(self._amplitudes)
+
+
+class SparseSimulator(cirq.SimulatesIntermediateStateVector):
+    def __init__(self):
+        super().__init__(split_untangled_states=False)
+
+    # override
+    def _can_be_in_run_prefix(self, val):
+        return super()._can_be_in_run_prefix(val) or isinstance(
+            val, PostSelectOperation
+        )
+
+    # abstract method of SimulatorBase
+    def _create_partial_simulation_state(
+        self, initial_state, qubits, logs=None, classical_data=None
+    ):
+        assert initial_state == 0
+        return SparseSimulationState(qubits=qubits)
+
+    # abstract method of SimulatorBase
+    def _create_step_result(self, sim_state):
+        return SparseSimulatorStep(sim_state=sim_state)
+
+
+class PostSelectOperation(cirq.Operation):
+    def __init__(self, qubit, value):
+        super().__init__()
+        self.qubit = qubit
+        self.value = value
+
+    def _act_on_(self, simulation_state):
+        simulation_state.post_select(self.qubit, self.value)
+        return True
+
+    @property
+    def qubits(self):
+        return (self.qubit,)
+
+    def with_qubits(self, new_qubit):
+        return PostSelectOperation(new_qubit, self.value)
+
+
+class SparseSimulatorStep(cirq.StepResultBase):
+    pass

--- a/unitary/alpha/sparse_vector_simulator_test.py
+++ b/unitary/alpha/sparse_vector_simulator_test.py
@@ -1,7 +1,13 @@
+import pytest
+
 import cirq
 from cirq.testing import random_circuit
 
-from unitary.alpha.sparse_vector_simulator import SparseSimulator, PostSelectOperation
+from unitary.alpha.sparse_vector_simulator import (
+    SparseSimulator,
+    PostSelectOperation,
+    InvalidPostSelectionError,
+)
 
 
 def test_simulation_fidelity():
@@ -58,3 +64,12 @@ def test_post_selection():
     assert 0.23 < sum((data.c1 == 1) & (data.c2 == 1)) / repetitions < 0.43
     assert 0.23 < sum((data.c1 == 1) & (data.c2 == 0)) / repetitions < 0.43
     assert 0.23 < sum((data.c1 == 0) & (data.c2 == 0)) / repetitions < 0.43
+
+
+def test_impossible_post_selection():
+    """Test post-selecting for a state with zero amplitude."""
+    sim = SparseSimulator()
+    qubit = cirq.NamedQubit("q")
+    circuit = cirq.Circuit(PostSelectOperation(qubit, 1), cirq.measure(qubit))
+    with pytest.raises(InvalidPostSelectionError):
+        sim.run(circuit, repetitions=100)

--- a/unitary/alpha/sparse_vector_simulator_test.py
+++ b/unitary/alpha/sparse_vector_simulator_test.py
@@ -1,0 +1,60 @@
+import cirq
+from cirq.testing import random_circuit
+
+from unitary.alpha.sparse_vector_simulator import SparseSimulator, PostSelectOperation
+
+
+def test_simulation_fidelity():
+    """Check that simulation results are roughly the same as a Cirq simulator."""
+    circuit = random_circuit(
+        qubits=10,
+        n_moments=20,
+        op_density=0.3,
+        gate_domain={
+            cirq.X: 1,
+            cirq.H: 1,
+            cirq.T: 1,
+            cirq.Z: 1,
+            cirq.Y: 1,
+            cirq.SWAP**0.5: 2,
+            cirq.ISWAP**0.5: 2,
+            cirq.CNOT: 2,
+            (cirq.SWAP**0.5).controlled(): 3,
+            (cirq.ISWAP**0.5).controlled(): 3,
+        },
+    )
+    circuit.append(cirq.measure(q) for q in circuit.all_qubits())
+    test_sim = SparseSimulator()
+    validation_sim = cirq.Simulator()
+    repetitions = 10000
+    test_data = test_sim.run(circuit, repetitions=repetitions).measurements
+    validation_data = validation_sim.run(circuit, repetitions=repetitions).measurements
+    for q in circuit.all_qubits():
+        test_ones_fraction = test_data[q.name].sum() / repetitions
+        validation_ones_fraction = validation_data[q.name].sum() / repetitions
+        assert abs(test_ones_fraction - validation_ones_fraction) < 0.1
+
+
+def test_post_selection():
+    """Test a circuit with PostSelectOperation."""
+    sim = SparseSimulator()
+    c1 = cirq.NamedQubit("c1")
+    c2 = cirq.NamedQubit("c2")
+    t = cirq.NamedQubit("t")
+    repetitions = 10000
+    circuit = cirq.Circuit(
+        cirq.H(c1),
+        cirq.H(c2),
+        cirq.X(t).controlled_by(c1, c2),
+        PostSelectOperation(t, 0),
+        cirq.X(c1),
+        cirq.measure(c1),
+        cirq.measure(c2),
+        cirq.measure(t),
+    )
+    data = sim.run(circuit, repetitions=repetitions).data
+    assert sum(data.t == 0) == repetitions
+    assert sum((data.c1 == 0) & (data.c2 == 1)) == 0
+    assert 0.23 < sum((data.c1 == 1) & (data.c2 == 1)) / repetitions < 0.43
+    assert 0.23 < sum((data.c1 == 1) & (data.c2 == 0)) / repetitions < 0.43
+    assert 0.23 < sum((data.c1 == 0) & (data.c2 == 0)) / repetitions < 0.43

--- a/unitary/examples/fox_in_a_hole/fox_in_a_hole.py
+++ b/unitary/examples/fox_in_a_hole/fox_in_a_hole.py
@@ -26,6 +26,7 @@ from unitary.alpha import (
     PhasedMove,
     Split,
     PhasedSplit,
+    SparseSimulator,
 )
 
 
@@ -172,7 +173,7 @@ class QuantumGame(Game):
                 f"Hole-{i}-{i}", Hole.FOX if i == index else Hole.EMPTY
             )
             holes.append(hole)
-        self.state = (QuantumWorld(holes), holes)
+        self.state = (QuantumWorld(holes, sampler=SparseSimulator()), holes)
 
     def state_to_string(self):
         return str(self.state[0].get_binary_probabilities(objects=self.state[1]))


### PR DESCRIPTION
Add a sparse state vector simulator which can be used as the sampler for a QuantumWorld. This speeds up simulation for circuits which use only a tiny fraction of the 2^n possible states. In addition to calculating on only the used states instead of all states, a post-selection operator is inserted into circuits when performing a measurement using the sparse simulator, which prunes the states not conforming with the measurement outcome.

Not sure what kind of unit tests we might want for sparse_vector_simulator. Is there like a standard test suite for Cirq simulators?