### PR TITLE
Add two example player classes to Quantum RPG

### DIFF
--- a/unitary/examples/quantum_rpg/classes.py
+++ b/unitary/examples/quantum_rpg/classes.py
@@ -1,0 +1,36 @@
+from typing import Any, Callable, Dict
+
+from unitary import alpha
+from unitary.examples.quantum_rpg import qaracter
+
+
+class Engineer(qaracter.Qaracter):
+    """Example player class that can do an X gate.
+
+    Engineeers can do an X gate at level 1 and a H gate at level 3.
+    """
+
+    def actions(self) -> Dict[str, Callable]:
+        actions = {
+            'x': lambda monster, qubit: monster.add_effect(alpha.Flip(), qubit)
+        }
+        if self.level >= 3:
+            actions['h'] = lambda monster, qubit: monster.add_effect(
+                alpha.Superposition(), qubit)
+        return actions
+
+
+class Analyst(qaracter.Qaracter):
+    """Example player class that can sample and measure.
+
+    Analysts can sample ('s') or measure ('m').
+    """
+
+    def actions(self) -> Dict[str, Callable]:
+        return {
+            's':
+                lambda monster, qubit: print(
+                    f'Sample result {monster.sample(qubit, False)}'),
+            'm':
+                lambda monster, qubit: monster.sample(qubit, True)
+        }

--- a/unitary/examples/quantum_rpg/classes.py
+++ b/unitary/examples/quantum_rpg/classes.py
@@ -12,10 +12,12 @@ class Engineer(qaracter.Qaracter):
 
     def actions(self) -> Dict[str, Callable]:
         actions = {
-            'x': lambda monster, qubit: monster.add_effect(alpha.Flip(), qubit)
+            'x':
+                lambda monster, qubit: monster.add_quantum_effect(
+                    alpha.Flip(), qubit)
         }
         if self.level >= 3:
-            actions['h'] = lambda monster, qubit: monster.add_effect(
+            actions['h'] = lambda monster, qubit: monster.add_quantum_effect(
                 alpha.Superposition(), qubit)
         return actions
 
@@ -29,8 +31,9 @@ class Analyst(qaracter.Qaracter):
     def actions(self) -> Dict[str, Callable]:
         return {
             's':
-                lambda monster, qubit: print(
-                    f'Sample result {monster.sample(qubit, False)}'),
+                lambda monster, qubit:
+                f'Sample result {monster.sample(monster.quantum_object_name(qubit), False)}',
             'm':
-                lambda monster, qubit: monster.sample(qubit, True)
+                lambda monster, qubit: monster.sample(
+                    monster.quantum_object_name(qubit), True)
         }

--- a/unitary/examples/quantum_rpg/classes_test.py
+++ b/unitary/examples/quantum_rpg/classes_test.py
@@ -1,0 +1,18 @@
+import unitary.examples.quantum_rpg.classes as classes
+
+def test_engineer():
+    qar = classes.Engineer(name='d')
+    assert not qar.is_npc()
+    assert set(qar.actions().keys()) == {'x'}
+    qar.add_hp()
+    assert set(qar.actions().keys()) == {'x'}
+    qar.add_hp()
+    assert set(qar.actions().keys()) == {'x', 'h'}
+
+def test_analyst():
+    qar = classes.Analyst(name='a')
+    assert not qar.is_npc()
+    assert set(qar.actions().keys()) == {'s', 'm'}
+    qar.add_hp()
+    qar.add_hp()
+    assert set(qar.actions().keys()) == {'s', 'm'}

--- a/unitary/examples/quantum_rpg/classes_test.py
+++ b/unitary/examples/quantum_rpg/classes_test.py
@@ -1,4 +1,8 @@
+import unitary.alpha as alpha
 import unitary.examples.quantum_rpg.classes as classes
+import unitary.examples.quantum_rpg.enums as enums
+import unitary.examples.quantum_rpg.qaracter as qaracter
+
 
 def test_engineer():
     qar = classes.Engineer(name='d')
@@ -8,6 +12,46 @@ def test_engineer():
     assert set(qar.actions().keys()) == {'x'}
     qar.add_hp()
     assert set(qar.actions().keys()) == {'x', 'h'}
+
+
+def test_engineer_effects():
+    qar = classes.Engineer(name='d')
+    qar.add_hp()
+    qar.add_hp()
+    test_monster = qaracter.Qaracter('t')
+
+    # Test X
+    qar.actions()['x'](test_monster, 1)
+    q = test_monster.quantum_object_name(1)
+    for _ in range(100):
+        assert test_monster.sample(q, False) == enums.HealthPoint.HEALTHY
+
+    # Test H
+    qar.actions()['h'](test_monster, 1)
+    results = [test_monster.sample(q, False) for _ in range(100)]
+    assert any(results[i] == enums.HealthPoint.HEALTHY for i in range(100))
+    assert any(results[i] == enums.HealthPoint.HURT for i in range(100))
+
+
+def test_analyst_effects():
+    qar = classes.Analyst(name='a')
+    test_monster = qaracter.Qaracter('t')
+
+    # Test sample
+    res = qar.actions()['s'](test_monster, 1)
+    assert res == 'Sample result HealthPoint.HURT'
+
+    # Test measurement
+    # First Hadamard to put into superposition
+    # Then test measurement destroys that superposition.
+    test_monster.add_quantum_effect(alpha.Superposition(), 1)
+    q = test_monster.quantum_object_name(1)
+    results = [test_monster.sample(q, False) for _ in range(100)]
+    assert not all(results[0] == results[i] for i in range(100))
+    qar.actions()['m'](test_monster, 1)
+    results = [test_monster.sample(q, False) for _ in range(100)]
+    assert all(results[0] == results[i] for i in range(100))
+
 
 def test_analyst():
     qar = classes.Analyst(name='a')


### PR DESCRIPTION
- This PR adds two very simple player classes to the quantum RPG.
- This PR is advance of a feature that can demonstrate an example battle.