### PR TITLE
Compile any `QuantumWorld` to qubits

### DIFF
--- a/unitary/alpha/quantum_effect_test.py
+++ b/unitary/alpha/quantum_effect_test.py
@@ -26,8 +26,7 @@ Q1 = cirq.NamedQubit("q1")
 @pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
 def test_quantum_if(simulator, compile_to_qubits):
-    board = alpha.QuantumWorld(sampler=simulator(),
-                               compile_to_qubits=compile_to_qubits)
+    board = alpha.QuantumWorld(sampler=simulator(), compile_to_qubits=compile_to_qubits)
     piece = alpha.QuantumObject("q0", 1)
     piece2 = alpha.QuantumObject("q1", 0)
     board.add_object(piece)
@@ -49,8 +48,7 @@ def test_quantum_if(simulator, compile_to_qubits):
 @pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
 def test_anti_control(simulator, compile_to_qubits):
-    board = alpha.QuantumWorld(sampler=simulator(),
-                               compile_to_qubits=compile_to_qubits)
+    board = alpha.QuantumWorld(sampler=simulator(), compile_to_qubits=compile_to_qubits)
     piece = alpha.QuantumObject("q0", 0)
     piece2 = alpha.QuantumObject("q1", 0)
     board.add_object(piece)

--- a/unitary/alpha/quantum_effect_test.py
+++ b/unitary/alpha/quantum_effect_test.py
@@ -23,9 +23,11 @@ Q0 = cirq.NamedQubit("q0")
 Q1 = cirq.NamedQubit("q1")
 
 
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
-def test_quantum_if(simulator):
-    board = alpha.QuantumWorld(sampler=simulator())
+def test_quantum_if(simulator, compile_to_qubits):
+    board = alpha.QuantumWorld(sampler=simulator(),
+                               compile_to_qubits=compile_to_qubits)
     piece = alpha.QuantumObject("q0", 1)
     piece2 = alpha.QuantumObject("q1", 0)
     board.add_object(piece)
@@ -44,9 +46,11 @@ def test_quantum_if(simulator):
     assert (result[1] == 1 for result in results)
 
 
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
-def test_anti_control(simulator):
-    board = alpha.QuantumWorld(sampler=simulator())
+def test_anti_control(simulator, compile_to_qubits):
+    board = alpha.QuantumWorld(sampler=simulator(),
+                               compile_to_qubits=compile_to_qubits)
     piece = alpha.QuantumObject("q0", 0)
     piece2 = alpha.QuantumObject("q1", 0)
     board.add_object(piece)
@@ -72,8 +76,9 @@ def test_no_world():
         alpha.Flip()(piece)
 
 
-def test_bad_length():
-    board = alpha.QuantumWorld()
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
+def test_bad_length(compile_to_qubits):
+    board = alpha.QuantumWorld(compile_to_qubits=compile_to_qubits)
     piece = alpha.QuantumObject("q0", 1)
     board.add_object(piece)
     with pytest.raises(ValueError, match="Not able to equate"):
@@ -83,8 +88,9 @@ def test_bad_length():
         alpha.Split()(piece)
 
 
-def test_no_qutrits():
-    board = alpha.QuantumWorld()
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
+def test_no_qutrits(compile_to_qubits):
+    board = alpha.QuantumWorld(compile_to_qubits=compile_to_qubits)
     piece = alpha.QuantumObject("q0", 2)
     board.add_object(piece)
     with pytest.raises(ValueError, match="Cannot apply effect to qids"):

--- a/unitary/alpha/quantum_object_test.py
+++ b/unitary/alpha/quantum_object_test.py
@@ -25,9 +25,9 @@ from unitary.alpha.sparse_vector_simulator import SparseSimulator
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
 def test_negation(simulator, compile_to_qubits):
     piece = alpha.QuantumObject("t", 0)
-    board = alpha.QuantumWorld(piece,
-                               sampler=simulator(),
-                               compile_to_qubits=compile_to_qubits)
+    board = alpha.QuantumWorld(
+        piece, sampler=simulator(), compile_to_qubits=compile_to_qubits
+    )
     assert board.peek() == [[0]]
     -piece
     assert board.peek() == [[1]]
@@ -42,9 +42,9 @@ def test_negation(simulator, compile_to_qubits):
 def test_add_world_after_state_change(simulator, compile_to_qubits):
     piece = alpha.QuantumObject("t", 0)
     piece += 1
-    board = alpha.QuantumWorld(piece,
-                               sampler=simulator(),
-                               compile_to_qubits=compile_to_qubits)
+    board = alpha.QuantumWorld(
+        piece, sampler=simulator(), compile_to_qubits=compile_to_qubits
+    )
     assert board.peek() == [[1]]
 
 

--- a/unitary/alpha/quantum_object_test.py
+++ b/unitary/alpha/quantum_object_test.py
@@ -21,10 +21,13 @@ import unitary.alpha as alpha
 from unitary.alpha.sparse_vector_simulator import SparseSimulator
 
 
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
-def test_negation(simulator):
+def test_negation(simulator, compile_to_qubits):
     piece = alpha.QuantumObject("t", 0)
-    board = alpha.QuantumWorld(piece, sampler=simulator())
+    board = alpha.QuantumWorld(piece,
+                               sampler=simulator(),
+                               compile_to_qubits=compile_to_qubits)
     assert board.peek() == [[0]]
     -piece
     assert board.peek() == [[1]]
@@ -34,17 +37,21 @@ def test_negation(simulator):
     assert board.peek() == [[1]]
 
 
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
-def test_add_world_after_state_change(simulator):
+def test_add_world_after_state_change(simulator, compile_to_qubits):
     piece = alpha.QuantumObject("t", 0)
     piece += 1
-    board = alpha.QuantumWorld(piece, sampler=simulator())
+    board = alpha.QuantumWorld(piece,
+                               sampler=simulator(),
+                               compile_to_qubits=compile_to_qubits)
     assert board.peek() == [[1]]
 
 
-def test_qutrit():
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
+def test_qutrit(compile_to_qubits):
     piece = alpha.QuantumObject("t", 2)
-    board = alpha.QuantumWorld(piece)
+    board = alpha.QuantumWorld(piece, compile_to_qubits=compile_to_qubits)
     assert board.peek() == [[2]]
     piece += 1
     assert board.peek() == [[0]]
@@ -58,14 +65,15 @@ def test_qutrit():
     assert board.peek() == [[2]]
 
 
-def test_enum():
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
+def test_enum(compile_to_qubits):
     class Color(enum.Enum):
         RED = 0
         YELLOW = 1
         GREEN = 2
 
     piece = alpha.QuantumObject("t", Color.YELLOW)
-    board = alpha.QuantumWorld(piece)
+    board = alpha.QuantumWorld(piece, compile_to_qubits=compile_to_qubits)
     assert board.peek() == [[Color.YELLOW]]
     piece += Color.YELLOW
     assert board.peek() == [[Color.GREEN]]

--- a/unitary/alpha/quantum_world.py
+++ b/unitary/alpha/quantum_world.py
@@ -40,7 +40,7 @@ class QuantumWorld:
     def __init__(self,
                  objects: Optional[List[QuantumObject]] = None,
                  sampler=cirq.Simulator(),
-                 compile_to_qubits: bool = True):
+                 compile_to_qubits: bool = False):
 
         self.clear()
         self.sampler = sampler

--- a/unitary/alpha/quantum_world_test.py
+++ b/unitary/alpha/quantum_world_test.py
@@ -88,8 +88,9 @@ def test_two_qutrits():
         [StopLight.YELLOW, StopLight.GREEN],
         [StopLight.YELLOW, StopLight.GREEN],
     ]
-    expected = "green (d=3): ────X(0_2)───\n\nyellow (d=3): ───X(0_1)───"
-    assert str(board.circuit) == expected
+    if not board.compile_to_qubits:
+        expected = "green (d=3): ────X(0_2)───\n\nyellow (d=3): ───X(0_1)───"
+        assert str(board.circuit) == expected
 
 
 @pytest.mark.parametrize("simulator", [cirq.Simulator, alpha.SparseSimulator])

--- a/unitary/alpha/qubit_effects_test.py
+++ b/unitary/alpha/qubit_effects_test.py
@@ -24,8 +24,7 @@ from unitary.alpha.sparse_vector_simulator import SparseSimulator
 @pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
 def test_flip(simulator, compile_to_qubits):
-    board = alpha.QuantumWorld(sampler=simulator(),
-                               compile_to_qubits=compile_to_qubits)
+    board = alpha.QuantumWorld(sampler=simulator(), compile_to_qubits=compile_to_qubits)
     piece = alpha.QuantumObject("t", 0)
     board.add_object(piece)
     alpha.Flip()(piece)
@@ -35,8 +34,7 @@ def test_flip(simulator, compile_to_qubits):
 @pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
 def test_superposition(simulator, compile_to_qubits):
-    board = alpha.QuantumWorld(sampler=simulator(),
-                               compile_to_qubits=compile_to_qubits)
+    board = alpha.QuantumWorld(sampler=simulator(), compile_to_qubits=compile_to_qubits)
     piece = alpha.QuantumObject("t", 0)
     board.add_object(piece)
     alpha.Superposition()(piece)
@@ -46,8 +44,7 @@ def test_superposition(simulator, compile_to_qubits):
 @pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
 def test_move(simulator, compile_to_qubits):
-    board = alpha.QuantumWorld(sampler=simulator(),
-                               compile_to_qubits=compile_to_qubits)
+    board = alpha.QuantumWorld(sampler=simulator(), compile_to_qubits=compile_to_qubits)
     piece1 = alpha.QuantumObject("a", 1)
     piece2 = alpha.QuantumObject("b", 0)
     board.add_object(piece1)
@@ -68,8 +65,7 @@ def test_move(simulator, compile_to_qubits):
 @pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
 def test_phased_move(simulator, compile_to_qubits):
-    board = alpha.QuantumWorld(sampler=simulator(),
-                               compile_to_qubits=compile_to_qubits)
+    board = alpha.QuantumWorld(sampler=simulator(), compile_to_qubits=compile_to_qubits)
     piece1 = alpha.QuantumObject("a", 1)
     piece2 = alpha.QuantumObject("b", 0)
     board.add_object(piece1)
@@ -90,8 +86,7 @@ def test_phased_move(simulator, compile_to_qubits):
 @pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
 def test_split(simulator, compile_to_qubits):
-    board = alpha.QuantumWorld(sampler=simulator(),
-                               compile_to_qubits=compile_to_qubits)
+    board = alpha.QuantumWorld(sampler=simulator(), compile_to_qubits=compile_to_qubits)
     piece1 = alpha.QuantumObject("a", 1)
     piece2 = alpha.QuantumObject("b", 0)
     piece3 = alpha.QuantumObject("c", 0)
@@ -104,17 +99,16 @@ def test_split(simulator, compile_to_qubits):
     b = cirq.NamedQubit("b")
     c = cirq.NamedQubit("c")
     expected_circuit.append(cirq.X(a))
-    expected_circuit.append(cirq.SWAP(a, b)**0.5)
-    expected_circuit.append(cirq.SWAP(a, c)**0.5)
-    expected_circuit.append(cirq.SWAP(a, c)**0.5)
+    expected_circuit.append(cirq.SWAP(a, b) ** 0.5)
+    expected_circuit.append(cirq.SWAP(a, c) ** 0.5)
+    expected_circuit.append(cirq.SWAP(a, c) ** 0.5)
     assert board.circuit == expected_circuit
 
 
 @pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
 def test_phased_split(simulator, compile_to_qubits):
-    board = alpha.QuantumWorld(sampler=simulator(),
-                               compile_to_qubits=compile_to_qubits)
+    board = alpha.QuantumWorld(sampler=simulator(), compile_to_qubits=compile_to_qubits)
     piece1 = alpha.QuantumObject("a", 1)
     piece2 = alpha.QuantumObject("b", 0)
     piece3 = alpha.QuantumObject("c", 0)
@@ -127,7 +121,7 @@ def test_phased_split(simulator, compile_to_qubits):
     b = cirq.NamedQubit("b")
     c = cirq.NamedQubit("c")
     expected_circuit.append(cirq.X(a))
-    expected_circuit.append(cirq.ISWAP(a, b)**0.5)
-    expected_circuit.append(cirq.ISWAP(a, c)**0.5)
-    expected_circuit.append(cirq.ISWAP(a, c)**0.5)
+    expected_circuit.append(cirq.ISWAP(a, b) ** 0.5)
+    expected_circuit.append(cirq.ISWAP(a, c) ** 0.5)
+    expected_circuit.append(cirq.ISWAP(a, c) ** 0.5)
     assert board.circuit == expected_circuit

--- a/unitary/alpha/qubit_effects_test.py
+++ b/unitary/alpha/qubit_effects_test.py
@@ -21,27 +21,33 @@ import unitary.alpha as alpha
 from unitary.alpha.sparse_vector_simulator import SparseSimulator
 
 
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
-def test_flip(simulator):
-    board = alpha.QuantumWorld(sampler=simulator())
+def test_flip(simulator, compile_to_qubits):
+    board = alpha.QuantumWorld(sampler=simulator(),
+                               compile_to_qubits=compile_to_qubits)
     piece = alpha.QuantumObject("t", 0)
     board.add_object(piece)
     alpha.Flip()(piece)
     assert board.circuit == cirq.Circuit(cirq.X(cirq.NamedQubit("t")))
 
 
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
-def test_superposition(simulator):
-    board = alpha.QuantumWorld(sampler=simulator())
+def test_superposition(simulator, compile_to_qubits):
+    board = alpha.QuantumWorld(sampler=simulator(),
+                               compile_to_qubits=compile_to_qubits)
     piece = alpha.QuantumObject("t", 0)
     board.add_object(piece)
     alpha.Superposition()(piece)
     assert board.circuit == cirq.Circuit(cirq.H(cirq.NamedQubit("t")))
 
 
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
-def test_move(simulator):
-    board = alpha.QuantumWorld(sampler=simulator())
+def test_move(simulator, compile_to_qubits):
+    board = alpha.QuantumWorld(sampler=simulator(),
+                               compile_to_qubits=compile_to_qubits)
     piece1 = alpha.QuantumObject("a", 1)
     piece2 = alpha.QuantumObject("b", 0)
     board.add_object(piece1)
@@ -59,9 +65,11 @@ def test_move(simulator):
     assert all(result == [0, 1] for result in results)
 
 
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
-def test_phased_move(simulator):
-    board = alpha.QuantumWorld(sampler=simulator())
+def test_phased_move(simulator, compile_to_qubits):
+    board = alpha.QuantumWorld(sampler=simulator(),
+                               compile_to_qubits=compile_to_qubits)
     piece1 = alpha.QuantumObject("a", 1)
     piece2 = alpha.QuantumObject("b", 0)
     board.add_object(piece1)
@@ -79,9 +87,11 @@ def test_phased_move(simulator):
     assert all(result == [0, 1] for result in results)
 
 
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
-def test_split(simulator):
-    board = alpha.QuantumWorld(sampler=simulator())
+def test_split(simulator, compile_to_qubits):
+    board = alpha.QuantumWorld(sampler=simulator(),
+                               compile_to_qubits=compile_to_qubits)
     piece1 = alpha.QuantumObject("a", 1)
     piece2 = alpha.QuantumObject("b", 0)
     piece3 = alpha.QuantumObject("c", 0)
@@ -94,15 +104,17 @@ def test_split(simulator):
     b = cirq.NamedQubit("b")
     c = cirq.NamedQubit("c")
     expected_circuit.append(cirq.X(a))
-    expected_circuit.append(cirq.SWAP(a, b) ** 0.5)
-    expected_circuit.append(cirq.SWAP(a, c) ** 0.5)
-    expected_circuit.append(cirq.SWAP(a, c) ** 0.5)
+    expected_circuit.append(cirq.SWAP(a, b)**0.5)
+    expected_circuit.append(cirq.SWAP(a, c)**0.5)
+    expected_circuit.append(cirq.SWAP(a, c)**0.5)
     assert board.circuit == expected_circuit
 
 
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize("simulator", [cirq.Simulator, SparseSimulator])
-def test_phased_split(simulator):
-    board = alpha.QuantumWorld(sampler=simulator())
+def test_phased_split(simulator, compile_to_qubits):
+    board = alpha.QuantumWorld(sampler=simulator(),
+                               compile_to_qubits=compile_to_qubits)
     piece1 = alpha.QuantumObject("a", 1)
     piece2 = alpha.QuantumObject("b", 0)
     piece3 = alpha.QuantumObject("c", 0)
@@ -115,7 +127,7 @@ def test_phased_split(simulator):
     b = cirq.NamedQubit("b")
     c = cirq.NamedQubit("c")
     expected_circuit.append(cirq.X(a))
-    expected_circuit.append(cirq.ISWAP(a, b) ** 0.5)
-    expected_circuit.append(cirq.ISWAP(a, c) ** 0.5)
-    expected_circuit.append(cirq.ISWAP(a, c) ** 0.5)
+    expected_circuit.append(cirq.ISWAP(a, b)**0.5)
+    expected_circuit.append(cirq.ISWAP(a, c)**0.5)
+    expected_circuit.append(cirq.ISWAP(a, c)**0.5)
     assert board.circuit == expected_circuit

--- a/unitary/alpha/qudit_effects_test.py
+++ b/unitary/alpha/qudit_effects_test.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 #
 import enum
-
-import cirq
+import pytest
 
 import unitary.alpha as alpha
 
@@ -25,8 +24,9 @@ class StopLight(enum.Enum):
     GREEN = 2
 
 
-def test_qudit_cycle():
-    board = alpha.QuantumWorld()
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
+def test_qudit_cycle(compile_to_qubits):
+    board = alpha.QuantumWorld(compile_to_qubits=compile_to_qubits)
     piece = alpha.QuantumObject("t", StopLight.GREEN)
     board.add_object(piece)
     alpha.QuditCycle(3)(piece)
@@ -43,8 +43,9 @@ def test_qudit_cycle():
     assert all(result == [StopLight.YELLOW] for result in results)
 
 
-def test_qudit_flip():
-    board = alpha.QuantumWorld()
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
+def test_qudit_flip(compile_to_qubits):
+    board = alpha.QuantumWorld(compile_to_qubits=compile_to_qubits)
     piece = alpha.QuantumObject("t", StopLight.GREEN)
     board.add_object(piece)
     alpha.QuditFlip(3, 0, 2)(piece)

--- a/unitary/alpha/qudit_state_transform.py
+++ b/unitary/alpha/qudit_state_transform.py
@@ -17,10 +17,10 @@ import itertools
 import numpy as np
 
 
-def _num_bits(num: int) -> int:
+def num_bits(num: int) -> int:
     """Returns the minimum number of bits needed to represent the input."""
     result = 1
-    while 2**result < num:
+    while num > 2**result:
         result += 1
     return result
 

--- a/unitary/alpha/qudit_state_transform.py
+++ b/unitary/alpha/qudit_state_transform.py
@@ -63,15 +63,14 @@ def qudit_to_qubit_state(
             Expected shape: `((2 ^ m) ^ num_qudits,)`.
     """
     # Reshape the state vector to a `num_qudits` rank tensor.
-    state_tensor = qudit_state_vector.reshape((qudit_dimension, ) * num_qudits)
+    state_tensor = qudit_state_vector.reshape((qudit_dimension,) * num_qudits)
     # Number of extra elements needed in each dimension if represented using qubits.
-    padding_amount = _nearest_power_of_two_ceiling(
-        qudit_dimension) - qudit_dimension
+    padding_amount = _nearest_power_of_two_ceiling(qudit_dimension) - qudit_dimension
     # Expand the number of elements in each dimension by the padding_amount. Fill
     # the new elements with the _pad_value.
-    padded_state_tensor = np.pad(state_tensor,
-                                 pad_width=(0, padding_amount),
-                                 constant_values=_pad_value)
+    padded_state_tensor = np.pad(
+        state_tensor, pad_width=(0, padding_amount), constant_values=_pad_value
+    )
     # Return a flattened state vector view of the final tensor.
     return np.ravel(padded_state_tensor)
 
@@ -102,10 +101,9 @@ def qubit_to_qudit_state(
     """
     mbit_dimension = _nearest_power_of_two_ceiling(qudit_dimension)
     # Reshape the state vector to a `num_qudits` rank tensor.
-    state_tensor = qubit_state_vector.reshape((mbit_dimension, ) * num_qudits)
+    state_tensor = qubit_state_vector.reshape((mbit_dimension,) * num_qudits)
     # Shrink the number of elements in each dimension up to the qudit_dimension, ignoring the rest.
-    trimmed_state_tensor = state_tensor[(slice(qudit_dimension), ) *
-                                        num_qudits]
+    trimmed_state_tensor = state_tensor[(slice(qudit_dimension),) * num_qudits]
     # Return a flattened state vector view of the final tensor.
     return np.ravel(trimmed_state_tensor)
 
@@ -141,8 +139,7 @@ def qudit_to_qubit_unitary(
         A numpy array representing the input unitary using m-qubits-per-qudit.
             Expected shape: `((2 ^ m) ^ num_qudits, (2 ^ m) ^ num_qudits)`.
     """
-    dim_qubit_space = _nearest_power_of_two_ceiling(
-        qudit_dimension)**num_qudits
+    dim_qubit_space = _nearest_power_of_two_ceiling(qudit_dimension) ** num_qudits
 
     if memoize:
         # Perform the transform of the below array from qubit to qudit space so that the indices
@@ -161,14 +158,14 @@ def qudit_to_qubit_unitary(
         iter_range = range(qudit_dimension**num_qudits)
         for i, j in itertools.product(iter_range, iter_range):
             # Use the index map to populate the appropriate element in the qubit representation.
-            result[d_to_b_index_map[i]][
-                d_to_b_index_map[j]] = qudit_unitary[i][j]
+            result[d_to_b_index_map[i]][d_to_b_index_map[j]] = qudit_unitary[i][j]
         return result
 
     # Treat the unitary as a num_qudits^2 system's state vector and represent it using qubits (pad
     # with 0s).
-    padded_unitary = qudit_to_qubit_state(qudit_dimension, num_qudits * 2,
-                                          np.ravel(qudit_unitary))
+    padded_unitary = qudit_to_qubit_state(
+        qudit_dimension, num_qudits * 2, np.ravel(qudit_unitary)
+    )
     # A qubit-based state vector with the extra padding bits having 1s and rest having 0s. This
     # vector marks only the bits that are padded.
     pad_qubits_vector = qudit_to_qubit_state(
@@ -180,8 +177,9 @@ def qudit_to_qubit_unitary(
     # Reshape the padded unitary to the final shape and add a diagonal matrix corresponding to the
     # pad_qubits_vector. This addition ensures that the invalid states with the "padding" bits map
     # to identity, preserving unitarity.
-    return padded_unitary.reshape(dim_qubit_space,
-                                  dim_qubit_space) + np.diag(pad_qubits_vector)
+    return padded_unitary.reshape(dim_qubit_space, dim_qubit_space) + np.diag(
+        pad_qubits_vector
+    )
 
 
 def qubit_to_qudit_unitary(
@@ -212,11 +210,12 @@ def qubit_to_qudit_unitary(
     # Treat unitary as a `num_qudits*2` qudit system state vector.
     effective_num_qudits = num_qudits * 2
     # Reshape the state vector to a `num_qudits*2` rank tensor.
-    unitary_tensor = qubit_unitary.reshape(
-        (mbit_dimension, ) * effective_num_qudits)
+    unitary_tensor = qubit_unitary.reshape((mbit_dimension,) * effective_num_qudits)
     # Shrink the number of elements in each dimension up to the qudit_dimension, ignoring the rest.
-    trimmed_unitary_tensor = unitary_tensor[(slice(qudit_dimension), ) *
-                                            effective_num_qudits]
+    trimmed_unitary_tensor = unitary_tensor[
+        (slice(qudit_dimension),) * effective_num_qudits
+    ]
     # Return a flat unitary view of the final tensor.
-    return trimmed_unitary_tensor.reshape(qudit_dimension**num_qudits,
-                                          qudit_dimension**num_qudits)
+    return trimmed_unitary_tensor.reshape(
+        qudit_dimension**num_qudits, qudit_dimension**num_qudits
+    )

--- a/unitary/alpha/qudit_state_transform.py
+++ b/unitary/alpha/qudit_state_transform.py
@@ -17,6 +17,14 @@ import itertools
 import numpy as np
 
 
+def _num_bits(num: int) -> int:
+    """Returns the minimum number of bits needed to represent the input."""
+    result = 1
+    while 2**result < num:
+        result += 1
+    return result
+
+
 def _nearest_power_of_two_ceiling(qudit_dim: int) -> int:
     """Returns the smallest power of two greater than or equal to qudit_dim."""
     if qudit_dim == 0:
@@ -55,14 +63,15 @@ def qudit_to_qubit_state(
             Expected shape: `((2 ^ m) ^ num_qudits,)`.
     """
     # Reshape the state vector to a `num_qudits` rank tensor.
-    state_tensor = qudit_state_vector.reshape((qudit_dimension,) * num_qudits)
+    state_tensor = qudit_state_vector.reshape((qudit_dimension, ) * num_qudits)
     # Number of extra elements needed in each dimension if represented using qubits.
-    padding_amount = _nearest_power_of_two_ceiling(qudit_dimension) - qudit_dimension
+    padding_amount = _nearest_power_of_two_ceiling(
+        qudit_dimension) - qudit_dimension
     # Expand the number of elements in each dimension by the padding_amount. Fill
     # the new elements with the _pad_value.
-    padded_state_tensor = np.pad(
-        state_tensor, pad_width=(0, padding_amount), constant_values=_pad_value
-    )
+    padded_state_tensor = np.pad(state_tensor,
+                                 pad_width=(0, padding_amount),
+                                 constant_values=_pad_value)
     # Return a flattened state vector view of the final tensor.
     return np.ravel(padded_state_tensor)
 
@@ -93,9 +102,10 @@ def qubit_to_qudit_state(
     """
     mbit_dimension = _nearest_power_of_two_ceiling(qudit_dimension)
     # Reshape the state vector to a `num_qudits` rank tensor.
-    state_tensor = qubit_state_vector.reshape((mbit_dimension,) * num_qudits)
+    state_tensor = qubit_state_vector.reshape((mbit_dimension, ) * num_qudits)
     # Shrink the number of elements in each dimension up to the qudit_dimension, ignoring the rest.
-    trimmed_state_tensor = state_tensor[(slice(qudit_dimension),) * num_qudits]
+    trimmed_state_tensor = state_tensor[(slice(qudit_dimension), ) *
+                                        num_qudits]
     # Return a flattened state vector view of the final tensor.
     return np.ravel(trimmed_state_tensor)
 
@@ -131,7 +141,8 @@ def qudit_to_qubit_unitary(
         A numpy array representing the input unitary using m-qubits-per-qudit.
             Expected shape: `((2 ^ m) ^ num_qudits, (2 ^ m) ^ num_qudits)`.
     """
-    dim_qubit_space = _nearest_power_of_two_ceiling(qudit_dimension) ** num_qudits
+    dim_qubit_space = _nearest_power_of_two_ceiling(
+        qudit_dimension)**num_qudits
 
     if memoize:
         # Perform the transform of the below array from qubit to qudit space so that the indices
@@ -150,14 +161,14 @@ def qudit_to_qubit_unitary(
         iter_range = range(qudit_dimension**num_qudits)
         for i, j in itertools.product(iter_range, iter_range):
             # Use the index map to populate the appropriate element in the qubit representation.
-            result[d_to_b_index_map[i]][d_to_b_index_map[j]] = qudit_unitary[i][j]
+            result[d_to_b_index_map[i]][
+                d_to_b_index_map[j]] = qudit_unitary[i][j]
         return result
 
     # Treat the unitary as a num_qudits^2 system's state vector and represent it using qubits (pad
     # with 0s).
-    padded_unitary = qudit_to_qubit_state(
-        qudit_dimension, num_qudits * 2, np.ravel(qudit_unitary)
-    )
+    padded_unitary = qudit_to_qubit_state(qudit_dimension, num_qudits * 2,
+                                          np.ravel(qudit_unitary))
     # A qubit-based state vector with the extra padding bits having 1s and rest having 0s. This
     # vector marks only the bits that are padded.
     pad_qubits_vector = qudit_to_qubit_state(
@@ -169,9 +180,8 @@ def qudit_to_qubit_unitary(
     # Reshape the padded unitary to the final shape and add a diagonal matrix corresponding to the
     # pad_qubits_vector. This addition ensures that the invalid states with the "padding" bits map
     # to identity, preserving unitarity.
-    return padded_unitary.reshape(dim_qubit_space, dim_qubit_space) + np.diag(
-        pad_qubits_vector
-    )
+    return padded_unitary.reshape(dim_qubit_space,
+                                  dim_qubit_space) + np.diag(pad_qubits_vector)
 
 
 def qubit_to_qudit_unitary(
@@ -202,12 +212,11 @@ def qubit_to_qudit_unitary(
     # Treat unitary as a `num_qudits*2` qudit system state vector.
     effective_num_qudits = num_qudits * 2
     # Reshape the state vector to a `num_qudits*2` rank tensor.
-    unitary_tensor = qubit_unitary.reshape((mbit_dimension,) * effective_num_qudits)
+    unitary_tensor = qubit_unitary.reshape(
+        (mbit_dimension, ) * effective_num_qudits)
     # Shrink the number of elements in each dimension up to the qudit_dimension, ignoring the rest.
-    trimmed_unitary_tensor = unitary_tensor[
-        (slice(qudit_dimension),) * effective_num_qudits
-    ]
+    trimmed_unitary_tensor = unitary_tensor[(slice(qudit_dimension), ) *
+                                            effective_num_qudits]
     # Return a flat unitary view of the final tensor.
-    return trimmed_unitary_tensor.reshape(
-        qudit_dimension**num_qudits, qudit_dimension**num_qudits
-    )
+    return trimmed_unitary_tensor.reshape(qudit_dimension**num_qudits,
+                                          qudit_dimension**num_qudits)

--- a/unitary/examples/tictactoe/tic_tac_split_test.py
+++ b/unitary/examples/tictactoe/tic_tac_split_test.py
@@ -82,6 +82,7 @@ b (d=3): ───×X───
     )
 
 
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
 @pytest.mark.parametrize(
     "mark, ruleset",
     [
@@ -91,10 +92,14 @@ b (d=3): ───×X───
         (tictactoe.TicTacSquare.O, tictactoe.TicTacRules.QUANTUM_V3),
     ],
 )
-def test_tic_tac_split(mark: tictactoe.TicTacSquare, ruleset: tictactoe.TicTacRules):
+def test_tic_tac_split(
+    mark: tictactoe.TicTacSquare,
+    ruleset: tictactoe.TicTacRules,
+    compile_to_qubits: bool,
+):
     a = alpha.QuantumObject("a", tictactoe.TicTacSquare.EMPTY)
     b = alpha.QuantumObject("b", tictactoe.TicTacSquare.EMPTY)
-    board = alpha.QuantumWorld([a, b])
+    board = alpha.QuantumWorld([a, b], compile_to_qubits=compile_to_qubits)
     tictactoe.TicTacSplit(mark, ruleset)(a, b)
     results = board.peek(count=1000)
     on_a = [mark, tictactoe.TicTacSquare.EMPTY]
@@ -104,11 +109,12 @@ def test_tic_tac_split(mark: tictactoe.TicTacSquare, ruleset: tictactoe.TicTacRu
     assert all(r == on_a or r == on_b for r in results)
 
 
-def test_tic_tac_split_entangled_v2():
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
+def test_tic_tac_split_entangled_v2(compile_to_qubits):
     a = alpha.QuantumObject("a", tictactoe.TicTacSquare.EMPTY)
     b = alpha.QuantumObject("b", tictactoe.TicTacSquare.EMPTY)
     c = alpha.QuantumObject("c", tictactoe.TicTacSquare.EMPTY)
-    board = alpha.QuantumWorld([a, b, c])
+    board = alpha.QuantumWorld([a, b, c], compile_to_qubits=compile_to_qubits)
     ruleset = tictactoe.TicTacRules.QUANTUM_V2
     tictactoe.TicTacSplit(tictactoe.TicTacSquare.X, ruleset)(a, b)
     tictactoe.TicTacSplit(tictactoe.TicTacSquare.O, ruleset)(b, c)
@@ -122,11 +128,12 @@ def test_tic_tac_split_entangled_v2():
     assert all(r == on_ab or r == on_ac or r == on_b for r in results)
 
 
-def test_tic_tac_split_entangled_v3():
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
+def test_tic_tac_split_entangled_v3(compile_to_qubits):
     a = alpha.QuantumObject("a", tictactoe.TicTacSquare.EMPTY)
     b = alpha.QuantumObject("b", tictactoe.TicTacSquare.EMPTY)
     c = alpha.QuantumObject("c", tictactoe.TicTacSquare.EMPTY)
-    board = alpha.QuantumWorld([a, b, c])
+    board = alpha.QuantumWorld([a, b, c], compile_to_qubits=compile_to_qubits)
     ruleset = tictactoe.TicTacRules.QUANTUM_V3
     tictactoe.TicTacSplit(tictactoe.TicTacSquare.X, ruleset)(a, b)
     tictactoe.TicTacSplit(tictactoe.TicTacSquare.O, ruleset)(b, c)
@@ -148,11 +155,12 @@ def test_tic_tac_split_entangled_v3():
     )
 
 
-def test_tic_tac_split_entangled_v3_empty():
+@pytest.mark.parametrize("compile_to_qubits", [False, True])
+def test_tic_tac_split_entangled_v3_empty(compile_to_qubits):
     a = alpha.QuantumObject("a", tictactoe.TicTacSquare.EMPTY)
     b = alpha.QuantumObject("b", tictactoe.TicTacSquare.EMPTY)
     c = alpha.QuantumObject("c", tictactoe.TicTacSquare.EMPTY)
-    board = alpha.QuantumWorld([a, b, c])
+    board = alpha.QuantumWorld([a, b, c], compile_to_qubits=compile_to_qubits)
     ruleset = tictactoe.TicTacRules.QUANTUM_V3
     tictactoe.TicTacSplit(tictactoe.TicTacSquare.X, ruleset)(a, b)
     tictactoe.TicTacSplit(tictactoe.TicTacSquare.O, ruleset)(c, b)

--- a/unitary/examples/tictactoe/tic_tac_toe.py
+++ b/unitary/examples/tictactoe/tic_tac_toe.py
@@ -18,9 +18,12 @@ from unitary.alpha.qudit_effects import QuditFlip
 from unitary.examples.tictactoe.enums import TicTacSquare, TicTacResult, TicTacRules
 from unitary.examples.tictactoe.tic_tac_split import TicTacSplit
 
-
 _SQUARE_NAMES = "abcdefghi"
-_MARK_SYMBOLS = {TicTacSquare.EMPTY: ".", TicTacSquare.X: "X", TicTacSquare.O: "O"}
+_MARK_SYMBOLS = {
+    TicTacSquare.EMPTY: ".",
+    TicTacSquare.X: "X",
+    TicTacSquare.O: "O"
+}
 
 # Possible ways to get three in a row (rows, columns, and diagonal) indices
 _POSSIBLE_WINS = [
@@ -35,7 +38,8 @@ _POSSIBLE_WINS = [
 ]
 
 
-def _histogram(results: List[List[TicTacSquare]]) -> List[Dict[TicTacSquare, int]]:
+def _histogram(
+        results: List[List[TicTacSquare]]) -> List[Dict[TicTacSquare, int]]:
     """Turns a list of whole board measurements into a histogram.
 
     Returns:
@@ -44,7 +48,11 @@ def _histogram(results: List[List[TicTacSquare]]) -> List[Dict[TicTacSquare, int
     """
     hist = []
     for idx in range(9):
-        hist.append({TicTacSquare.EMPTY: 0, TicTacSquare.X: 0, TicTacSquare.O: 0})
+        hist.append({
+            TicTacSquare.EMPTY: 0,
+            TicTacSquare.X: 0,
+            TicTacSquare.O: 0
+        })
     for r in results:
         for idx in range(9):
             hist[idx][r[idx]] += 1
@@ -100,12 +108,13 @@ class TicTacToe:
     human-friendly text format or by using `sample()` to get one
     or more samples (measurements) of the board.
     """
-
-    def __init__(self, rules: TicTacRules = TicTacRules.QUANTUM_V3):
-        self.clear()
+    def __init__(self,
+                 rules: TicTacRules = TicTacRules.QUANTUM_V3,
+                 run_on_hardware: bool = False):
+        self.clear(run_on_hardware)
         self.rules = rules
 
-    def clear(self) -> None:
+    def clear(self, run_on_hardware: bool = False) -> None:
         """Clears the TicTacToe board.
 
         Sets all 9 squares to empty.
@@ -116,7 +125,8 @@ class TicTacToe:
         for name in _SQUARE_NAMES:
             self.empty_squares.add(name)
             self.squares[name] = QuantumObject(name, TicTacSquare.EMPTY)
-        self.board = QuantumWorld(list(self.squares.values()))
+        self.board = QuantumWorld(list(self.squares.values()),
+                                  compile_to_qubits=run_on_hardware)
 
     def result(self) -> TicTacResult:
         """Returns the result of the TicTacToe game.
@@ -153,13 +163,13 @@ class TicTacToe:
         if len(move) > 2 or len(move) == 0:
             raise ValueError(f"Your move ({move}) must be one or two letters.")
         if not all(m in _SQUARE_NAMES for m in move):
-            raise ValueError(f"Your move ({move}) can only have these: {_SQUARE_NAMES}")
+            raise ValueError(
+                f"Your move ({move}) can only have these: {_SQUARE_NAMES}")
         if len(move) == 1:
             # Check if the square is empty
             if move not in self.empty_squares:
                 raise ValueError(
-                    f"You cannot put your token on non-empty square {move}"
-                )
+                    f"You cannot put your token on non-empty square {move}")
             # Flip the square to the correct value (mark.value)
             QuditFlip(3, 0, mark.value)(self.squares[move])
             # This square is now no longer empty
@@ -168,33 +178,26 @@ class TicTacToe:
             # Check if rules allow quantum moves
             if self.rules == TicTacRules.CLASSICAL:
                 raise ValueError(
-                    f"Quantum moves are not allowed in a classical TicTacToe"
-                )
+                    f"Quantum moves are not allowed in a classical TicTacToe")
 
             # Check if either square is non-empty. Splitting on top of
             # non-empty squares is only allowed at full quantumness
-            if (
-                (move[0] not in self.empty_squares)
-                or (move[1] not in self.empty_squares)
-            ) and (self.rules == TicTacRules.QUANTUM_V1):
+            if ((move[0] not in self.empty_squares) or
+                (move[1] not in self.empty_squares)) and (
+                    self.rules == TicTacRules.QUANTUM_V1):
                 raise ValueError(
                     f"This ruleset ({0}) does not allow splits on \
-                              top of non-empty squares".format(
-                        self.rules
-                    )
-                )
+                              top of non-empty squares".format(self.rules))
 
             # TicTacSplit first flips the first square before performing a split
             # If either of the two involved squares is empty, we want to do the
             # split on that square.
             if move[1] in self.empty_squares:
-                TicTacSplit(mark, self.rules)(
-                    self.squares[move[1]], self.squares[move[0]]
-                )
+                TicTacSplit(mark, self.rules)(self.squares[move[1]],
+                                              self.squares[move[0]])
             else:
-                TicTacSplit(mark, self.rules)(
-                    self.squares[move[0]], self.squares[move[1]]
-                )
+                TicTacSplit(mark, self.rules)(self.squares[move[0]],
+                                              self.squares[move[1]])
 
             # The involved squares are now no longer empty
             self.empty_squares.discard(move[0])
@@ -219,7 +222,9 @@ class TicTacToe:
 
         would return '.X.XO..OO'.
         """
-        return [_result_to_str(result) for result in self.board.peek(count=count)]
+        return [
+            _result_to_str(result) for result in self.board.peek(count=count)
+        ]
 
     def print(self) -> str:
         """Returns the TicTacToe board in ASCII form."""

--- a/unitary/examples/tictactoe/tic_tac_toe.py
+++ b/unitary/examples/tictactoe/tic_tac_toe.py
@@ -19,11 +19,7 @@ from unitary.examples.tictactoe.enums import TicTacSquare, TicTacResult, TicTacR
 from unitary.examples.tictactoe.tic_tac_split import TicTacSplit
 
 _SQUARE_NAMES = "abcdefghi"
-_MARK_SYMBOLS = {
-    TicTacSquare.EMPTY: ".",
-    TicTacSquare.X: "X",
-    TicTacSquare.O: "O"
-}
+_MARK_SYMBOLS = {TicTacSquare.EMPTY: ".", TicTacSquare.X: "X", TicTacSquare.O: "O"}
 
 # Possible ways to get three in a row (rows, columns, and diagonal) indices
 _POSSIBLE_WINS = [
@@ -38,8 +34,7 @@ _POSSIBLE_WINS = [
 ]
 
 
-def _histogram(
-        results: List[List[TicTacSquare]]) -> List[Dict[TicTacSquare, int]]:
+def _histogram(results: List[List[TicTacSquare]]) -> List[Dict[TicTacSquare, int]]:
     """Turns a list of whole board measurements into a histogram.
 
     Returns:
@@ -48,11 +43,7 @@ def _histogram(
     """
     hist = []
     for idx in range(9):
-        hist.append({
-            TicTacSquare.EMPTY: 0,
-            TicTacSquare.X: 0,
-            TicTacSquare.O: 0
-        })
+        hist.append({TicTacSquare.EMPTY: 0, TicTacSquare.X: 0, TicTacSquare.O: 0})
     for r in results:
         for idx in range(9):
             hist[idx][r[idx]] += 1
@@ -108,9 +99,10 @@ class TicTacToe:
     human-friendly text format or by using `sample()` to get one
     or more samples (measurements) of the board.
     """
-    def __init__(self,
-                 rules: TicTacRules = TicTacRules.QUANTUM_V3,
-                 run_on_hardware: bool = False):
+
+    def __init__(
+        self, rules: TicTacRules = TicTacRules.QUANTUM_V3, run_on_hardware: bool = False
+    ):
         self.clear(run_on_hardware)
         self.rules = rules
 
@@ -125,8 +117,9 @@ class TicTacToe:
         for name in _SQUARE_NAMES:
             self.empty_squares.add(name)
             self.squares[name] = QuantumObject(name, TicTacSquare.EMPTY)
-        self.board = QuantumWorld(list(self.squares.values()),
-                                  compile_to_qubits=run_on_hardware)
+        self.board = QuantumWorld(
+            list(self.squares.values()), compile_to_qubits=run_on_hardware
+        )
 
     def result(self) -> TicTacResult:
         """Returns the result of the TicTacToe game.
@@ -163,13 +156,13 @@ class TicTacToe:
         if len(move) > 2 or len(move) == 0:
             raise ValueError(f"Your move ({move}) must be one or two letters.")
         if not all(m in _SQUARE_NAMES for m in move):
-            raise ValueError(
-                f"Your move ({move}) can only have these: {_SQUARE_NAMES}")
+            raise ValueError(f"Your move ({move}) can only have these: {_SQUARE_NAMES}")
         if len(move) == 1:
             # Check if the square is empty
             if move not in self.empty_squares:
                 raise ValueError(
-                    f"You cannot put your token on non-empty square {move}")
+                    f"You cannot put your token on non-empty square {move}"
+                )
             # Flip the square to the correct value (mark.value)
             QuditFlip(3, 0, mark.value)(self.squares[move])
             # This square is now no longer empty
@@ -178,26 +171,33 @@ class TicTacToe:
             # Check if rules allow quantum moves
             if self.rules == TicTacRules.CLASSICAL:
                 raise ValueError(
-                    f"Quantum moves are not allowed in a classical TicTacToe")
+                    f"Quantum moves are not allowed in a classical TicTacToe"
+                )
 
             # Check if either square is non-empty. Splitting on top of
             # non-empty squares is only allowed at full quantumness
-            if ((move[0] not in self.empty_squares) or
-                (move[1] not in self.empty_squares)) and (
-                    self.rules == TicTacRules.QUANTUM_V1):
+            if (
+                (move[0] not in self.empty_squares)
+                or (move[1] not in self.empty_squares)
+            ) and (self.rules == TicTacRules.QUANTUM_V1):
                 raise ValueError(
                     f"This ruleset ({0}) does not allow splits on \
-                              top of non-empty squares".format(self.rules))
+                              top of non-empty squares".format(
+                        self.rules
+                    )
+                )
 
             # TicTacSplit first flips the first square before performing a split
             # If either of the two involved squares is empty, we want to do the
             # split on that square.
             if move[1] in self.empty_squares:
-                TicTacSplit(mark, self.rules)(self.squares[move[1]],
-                                              self.squares[move[0]])
+                TicTacSplit(mark, self.rules)(
+                    self.squares[move[1]], self.squares[move[0]]
+                )
             else:
-                TicTacSplit(mark, self.rules)(self.squares[move[0]],
-                                              self.squares[move[1]])
+                TicTacSplit(mark, self.rules)(
+                    self.squares[move[0]], self.squares[move[1]]
+                )
 
             # The involved squares are now no longer empty
             self.empty_squares.discard(move[0])
@@ -222,9 +222,7 @@ class TicTacToe:
 
         would return '.X.XO..OO'.
         """
-        return [
-            _result_to_str(result) for result in self.board.peek(count=count)
-        ]
+        return [_result_to_str(result) for result in self.board.peek(count=count)]
 
     def print(self) -> str:
         """Returns the TicTacToe board in ASCII form."""

--- a/unitary/examples/tictactoe/tic_tac_toe_test.py
+++ b/unitary/examples/tictactoe/tic_tac_toe_test.py
@@ -53,8 +53,9 @@ def test_eval_board(result, expected):
     assert tictactoe.tic_tac_toe.eval_board(result) == expected
 
 
-def test_measure():
-    board = tictactoe.TicTacToe()
+@pytest.mark.parametrize("run_on_hardware", [False, True])
+def test_measure(run_on_hardware):
+    board = tictactoe.TicTacToe(run_on_hardware=run_on_hardware)
     board.move("ab", tictactoe.TicTacSquare.X)
     board.move("cd", tictactoe.TicTacSquare.O)
     board.move("ef", tictactoe.TicTacSquare.X)
@@ -95,8 +96,9 @@ def test_measure():
     assert all(result == expected for result in results)
 
 
-def test_sample():
-    board = tictactoe.TicTacToe()
+@pytest.mark.parametrize("run_on_hardware", [False, True])
+def test_sample(run_on_hardware):
+    board = tictactoe.TicTacToe(run_on_hardware=run_on_hardware)
     board.move("a", tictactoe.TicTacSquare.X)
     board.move("e", tictactoe.TicTacSquare.O)
     results = board.sample(count=100)
@@ -109,8 +111,9 @@ def test_sample():
     assert all(result == "X...O..OX" for result in results)
 
 
-def test_split():
-    board = tictactoe.TicTacToe()
+@pytest.mark.parametrize("run_on_hardware", [False, True])
+def test_split(run_on_hardware):
+    board = tictactoe.TicTacToe(run_on_hardware=run_on_hardware)
     board.move("ab", tictactoe.TicTacSquare.X)
     results = board.sample(count=1000)
     assert len(results) == 1000
@@ -121,21 +124,27 @@ def test_split():
     assert all(result == in_a or result == in_b for result in results)
 
 
-def test_rulesets():
+@pytest.mark.parametrize("run_on_hardware", [False, True])
+def test_rulesets(run_on_hardware):
     # Try to make a quantum move with classical rules
-    board = tictactoe.TicTacToe(tictactoe.TicTacRules.CLASSICAL)
+    board = tictactoe.TicTacToe(
+        tictactoe.TicTacRules.CLASSICAL, run_on_hardware=run_on_hardware
+    )
     with pytest.raises(ValueError):
         board.move("ab", tictactoe.TicTacSquare.X)
 
     # Try to make a split move on non-empty squares at minimal quantum
-    board = tictactoe.TicTacToe(tictactoe.TicTacRules.QUANTUM_V1)
+    board = tictactoe.TicTacToe(
+        tictactoe.TicTacRules.QUANTUM_V1, run_on_hardware=run_on_hardware
+    )
     board.move("a", tictactoe.TicTacSquare.X)
     with pytest.raises(ValueError):
         board.move("ab", tictactoe.TicTacSquare.O)
 
 
-def test_print():
-    board = tictactoe.TicTacToe()
+@pytest.mark.parametrize("run_on_hardware", [False, True])
+def test_print(run_on_hardware):
+    board = tictactoe.TicTacToe(run_on_hardware=run_on_hardware)
     board.move("a", tictactoe.TicTacSquare.X)
     board.move("e", tictactoe.TicTacSquare.O)
     output = board.print()


### PR DESCRIPTION
For enabling hardware-based runs, added an option to `QuantumWorld` that replaces qudits by ancilla qubits and transforms any qudit-based `QuantumEffect` and measurements to be qubit-based. Uses the utils added in #69 for the actual unitary transformations.

Updated all the applicable tests under `unitary/alpha` and `unitary/examples/tictactoe` to run in both regular mode and qubit-compiled mode.

This is still not all-powerful because the underlying qudit-to-qubit transforms assumed that all qudits in the system have the same dimension. Will work on generalizing that further next.