### PR TITLE
Add items to Quantum RPG

### DIFF
--- a/unitary/examples/quantum_rpg/item.py
+++ b/unitary/examples/quantum_rpg/item.py
@@ -27,7 +27,11 @@ class Item:
     def __init__(
         self,
         keyword_actions: Sequence[
-            Tuple[Union[str, Sequence[str]], Optional[Union[str,Sequence[str]]], Union[str, Callable]]
+            Tuple[
+                Union[str, Sequence[str]],
+                Optional[Union[str, Sequence[str]]],
+                Union[str, Callable],
+            ]
         ],
         description: Optional[str] = None,
     ):
@@ -36,14 +40,16 @@ class Item:
 
     def get_action(self, user_input: str) -> Optional[Union[str, Callable]]:
         words = user_input.lower().split()
+        if not words:
+            return None
         keyword = words[0]
-        target = words[1] if len(words)>1 else None
+        target = words[1] if len(words) > 1 else None
         for keywords, targets, action in self.keyword_actions:
             if isinstance(targets, str):
-              targets=[targets]
+                targets = [targets]
             if keyword == keywords or keyword in keywords:
-              if not targets or target in targets:
-                return action
-              if target is None and targets:
-                return f"{keyword} what?"
+                if not targets or target in targets:
+                    return action
+                if target is None and targets:
+                    return f"{keyword} what?"
         return None

--- a/unitary/examples/quantum_rpg/item.py
+++ b/unitary/examples/quantum_rpg/item.py
@@ -1,0 +1,37 @@
+from typing import Callable, Optional, Sequence, Tuple, TYPE_CHECKING, Union
+
+
+class Item:
+    """An item is an object or person that can be interacted with.
+
+    items have keywords that you can associate with them to
+    interact with them, such as 'talk' for people, or press for
+    button.
+
+    Future functionality may allow these items to be picked up
+    as well.
+
+    Attributes:
+        keyword_actions: Tuples of keywords to actions.  A keyword
+           is a single verb that can be used to interact with the item.
+           An action is a string that is printed out, or a callable
+           that will perform some sort of action.
+        description: Optional string that will be printed out as
+           part of the room description.
+    """
+
+    def __init__(
+        self,
+        keyword_actions: Sequence[
+            Tuple[Union[str, Sequence[str]], Union[str, Callable]]
+        ],
+        description: Optional[str] = None,
+    ):
+        self.keyword_actions = keyword_actions
+        self.description = description
+
+    def get_action(self, keyword: str) -> Optional[Union[str, Callable]]:
+        for keywords, action in self.keyword_actions:
+            if keyword == keywords or keyword in keywords:
+                return action
+        return None

--- a/unitary/examples/quantum_rpg/item.py
+++ b/unitary/examples/quantum_rpg/item.py
@@ -12,10 +12,14 @@ class Item:
     as well.
 
     Attributes:
-        keyword_actions: Tuples of keywords to actions.  A keyword
+        keyword_actions: Tuples of keywords and targets to actions.  A keyword
            is a single verb that can be used to interact with the item.
            An action is a string that is printed out, or a callable
            that will perform some sort of action.
+        keyword_targets:  Optional list of targets.  For instance,
+           ['Erwin', 'physicist'] would match 'talk Erwin' or
+           'talk physicist'. If this is blank, the item will
+           intercept all commands with the keyword_actions.
         description: Optional string that will be printed out as
            part of the room description.
     """
@@ -23,15 +27,23 @@ class Item:
     def __init__(
         self,
         keyword_actions: Sequence[
-            Tuple[Union[str, Sequence[str]], Union[str, Callable]]
+            Tuple[Union[str, Sequence[str]], Optional[Union[str,Sequence[str]]], Union[str, Callable]]
         ],
         description: Optional[str] = None,
     ):
         self.keyword_actions = keyword_actions
         self.description = description
 
-    def get_action(self, keyword: str) -> Optional[Union[str, Callable]]:
-        for keywords, action in self.keyword_actions:
+    def get_action(self, user_input: str) -> Optional[Union[str, Callable]]:
+        words = user_input.lower().split()
+        keyword = words[0]
+        target = words[1] if len(words)>1 else None
+        for keywords, targets, action in self.keyword_actions:
+            if isinstance(targets, str):
+              targets=[targets]
             if keyword == keywords or keyword in keywords:
+              if not targets or target in targets:
                 return action
+              if target is None and targets:
+                return f"{keyword} what?"
         return None

--- a/unitary/examples/quantum_rpg/item_test.py
+++ b/unitary/examples/quantum_rpg/item_test.py
@@ -1,15 +1,21 @@
 import unitary.examples.quantum_rpg.item as item
 
 
-def test_itemi_str():
+def test_item_str():
     sign = item.Item(
         keyword_actions=[
-            (["read", "examine"], "Keep out"),
-            ("pass", "Or enter, Im a sign, not a cop"),
+            (["read", "examine"], ["sign", "message"], "Keep out"),
+            ("pass", [], "Or enter, Im a sign, not a cop"),
         ],
         description="A sign blocks the way forward.",
     )
-    assert sign.get_action("read") == "Keep out"
-    assert sign.get_action("examine") == "Keep out"
+    assert sign.get_action("read") == "read what?"
+    assert sign.get_action("examine") == "examine what?"
+    assert sign.get_action("READ SIGN") == "Keep out"
+    assert sign.get_action("READ MESSAGE") == "Keep out"
+    assert sign.get_action("read letter") is None
     assert sign.get_action("pass") == "Or enter, Im a sign, not a cop"
+    assert sign.get_action("pass sign") == "Or enter, Im a sign, not a cop"
+    assert sign.get_action("pass by") == "Or enter, Im a sign, not a cop"
+    assert sign.get_action("eat sign") is None
     assert sign.description == "A sign blocks the way forward."

--- a/unitary/examples/quantum_rpg/item_test.py
+++ b/unitary/examples/quantum_rpg/item_test.py
@@ -1,0 +1,15 @@
+import unitary.examples.quantum_rpg.item as item
+
+
+def test_itemi_str():
+    sign = item.Item(
+        keyword_actions=[
+            (["read", "examine"], "Keep out"),
+            ("pass", "Or enter, Im a sign, not a cop"),
+        ],
+        description="A sign blocks the way forward.",
+    )
+    assert sign.get_action("read") == "Keep out"
+    assert sign.get_action("examine") == "Keep out"
+    assert sign.get_action("pass") == "Or enter, Im a sign, not a cop"
+    assert sign.description == "A sign blocks the way forward."

--- a/unitary/examples/quantum_rpg/item_test.py
+++ b/unitary/examples/quantum_rpg/item_test.py
@@ -19,3 +19,5 @@ def test_item_str():
     assert sign.get_action("pass by") == "Or enter, Im a sign, not a cop"
     assert sign.get_action("eat sign") is None
     assert sign.description == "A sign blocks the way forward."
+
+    assert sign.get_action("") is None

--- a/unitary/examples/quantum_rpg/main_loop.py
+++ b/unitary/examples/quantum_rpg/main_loop.py
@@ -97,11 +97,10 @@ class MainLoop:
             if cmd is not None:
                 self.world.move(cmd)
                 continue
-            words = current_input.split()
-            action = self.world.current_location.get_action(words[0])
+            action = self.world.current_location.get_action(current_input)
             if action is not None:
                 if isinstance(action, str):
-                    print(action + "\n", file=self.file)
+                    print(action, file=self.file)
                 print_room_description = False
                 # TODO: actions that are 'callables'
                 continue

--- a/unitary/examples/quantum_rpg/main_loop.py
+++ b/unitary/examples/quantum_rpg/main_loop.py
@@ -57,7 +57,6 @@ class MainLoop:
         self.file = file
         self.party = party
 
-
     def print_title_screen(self):
         print(ascii_art.TITLE_SCREEN, file=self.file)
 
@@ -67,15 +66,21 @@ class MainLoop:
         Returns the result of a battle as an enum.
         """
         get_user_input = input_helpers.get_user_input_function(user_input)
+        print_room_description = True
         while True:
-            print(self.world.current_location, file=self.file)
+            if print_room_description:
+                print(self.world.current_location, file=self.file)
+            else:
+                print_room_description = True
             if self.world.current_location.encounters:
                 result = None
                 for random_encounter in self.world.current_location.encounters:
                     if random_encounter.will_trigger():
                         if random_encounter.description:
                             print(random_encounter.description, file=self.file)
-                        current_battle = random_encounter.initiate(self.party, file=self.file)
+                        current_battle = random_encounter.initiate(
+                            self.party, file=self.file
+                        )
                         result = current_battle.loop(get_user_input=get_user_input)
                         self.world.current_location.remove_encounter(random_encounter)
 
@@ -91,6 +96,14 @@ class MainLoop:
             cmd = world.Direction.parse(current_input)
             if cmd is not None:
                 self.world.move(cmd)
+                continue
+            words = current_input.split()
+            action = self.world.current_location.get_action(words[0])
+            if action is not None:
+                if isinstance(action, str):
+                    print(action + "\n", file=self.file)
+                print_room_description = False
+                # TODO: actions that are 'callables'
                 continue
             cmd = Command.parse(current_input)
             if cmd == Command.QUIT:

--- a/unitary/examples/quantum_rpg/main_loop_test.py
+++ b/unitary/examples/quantum_rpg/main_loop_test.py
@@ -15,9 +15,15 @@
 import io
 import unitary.examples.quantum_rpg.classes as classes
 import unitary.examples.quantum_rpg.encounter as encounter
+import unitary.examples.quantum_rpg.item as item
 import unitary.examples.quantum_rpg.main_loop as main_loop
 import unitary.examples.quantum_rpg.npcs as npcs
 import unitary.examples.quantum_rpg.world as world
+
+SIGN = item.Item(
+    keyword_actions=[("read", "This is an example world!")],
+    description="A helpful sign is here.",
+)
 
 EXAMPLE_WORLD = [
     world.Location(
@@ -30,6 +36,7 @@ EXAMPLE_WORLD = [
         label="2",
         title="Disorganized Lab",
         description="Tables are here with tons of electronics.\nThe lab continues to the south.",
+        items=[SIGN],
         exits={world.Direction.SOUTH: "3", world.Direction.WEST: "1"},
     ),
     world.Location(
@@ -77,7 +84,7 @@ def test_do_simple_move() -> None:
     output = io.StringIO()
     c = classes.Analyst("Mensing")
     loop = main_loop.MainLoop([c], world.World(EXAMPLE_WORLD), output)
-    loop.loop(user_input=["e", "w", "quit"])
+    loop.loop(user_input=["e", "read sign", "w", "quit"])
     assert (
         output.getvalue().replace("\t", " ").strip()
         == r"""
@@ -91,7 +98,10 @@ Disorganized Lab
 
 Tables are here with tons of electronics.
 The lab continues to the south.
+A helpful sign is here.
 Exits: south, west.
+
+This is an example world!
 
 Lab Entrance
 
@@ -122,6 +132,7 @@ Disorganized Lab
 
 Tables are here with tons of electronics.
 The lab continues to the south.
+A helpful sign is here.
 Exits: south, west.
 
 Cryostats
@@ -148,12 +159,15 @@ Exits: north.
 """.strip()
     )
 
+
 def test_title_screen():
     output = io.StringIO()
     loop = main_loop.MainLoop([], world.World(EXAMPLE_WORLD), output)
     loop.print_title_screen()
 
-    assert output.getvalue() == r"""
+    assert (
+        output.getvalue()
+        == r"""
 ______  _                _             _____  _           _
 |  ___|(_)              | |           /  ___|| |         | |
 | |_    _  _ __    __ _ | |    __     \ `--. | |_   __ _ | |_   ___
@@ -172,3 +186,4 @@ ______                         ||              _    _
                    |_|         \/
 
 """
+    )

--- a/unitary/examples/quantum_rpg/main_loop_test.py
+++ b/unitary/examples/quantum_rpg/main_loop_test.py
@@ -21,7 +21,7 @@ import unitary.examples.quantum_rpg.npcs as npcs
 import unitary.examples.quantum_rpg.world as world
 
 SIGN = item.Item(
-    keyword_actions=[("read", "This is an example world!")],
+    keyword_actions=[("read", "sign", "This is an example world!")],
     description="A helpful sign is here.",
 )
 
@@ -102,7 +102,6 @@ A helpful sign is here.
 Exits: south, west.
 
 This is an example world!
-
 Lab Entrance
 
 You stand before the entrance to the premier quantum lab.

--- a/unitary/examples/quantum_rpg/world.py
+++ b/unitary/examples/quantum_rpg/world.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Optional, Sequence
+from typing import Callable, Dict, List, Optional, Sequence, Union
 
 import dataclasses
 import unitary.examples.quantum_rpg.encounter as encounter
+import unitary.examples.quantum_rpg.item as item
 import enum
 
 
@@ -62,15 +63,29 @@ class Location:
     exits: Dict[Direction, str]
     encounters: Optional[List[encounter.Encounter]] = None
     description: Optional[str] = None
+    items: Optional[List[item.Item]] = None
 
     def _exits(self) -> str:
         return ", ".join([ex.value for ex in self.exits]) + "."
+
+    def _item_str(self) -> str:
+        if not self.items:
+            return ""
+        return "\n" + "\n".join([item.description or "" for item in self.items])
+
+    def get_action(self, keyword: str) -> Union[str, Callable]:
+        if self.items:
+            for item in self.items:
+                action = item.get_action(keyword)
+                if action:
+                    return action
+        return None
 
     def remove_encounter(self, triggered_encounter) -> bool:
         self.encounters.remove(triggered_encounter)
 
     def __str__(self) -> str:
-        return f"{self.title}\n\n{self.description}\nExits: {self._exits()}\n"
+        return f"{self.title}\n\n{self.description}{self._item_str()}\nExits: {self._exits()}\n"
 
 
 class World:

--- a/unitary/examples/quantum_rpg/world_test.py
+++ b/unitary/examples/quantum_rpg/world_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unitary.examples.quantum_rpg.item as item
 import unitary.examples.quantum_rpg.world as world
 
 


### PR DESCRIPTION
- Add items you can interact with in Quantum RPG.
- These will be useful for signs, helpful NPCS, and puzzles.
- Right now, they can only print out a string.

Follow-up PRs will hook in custom functions for more complicated puzzles.  For right now, there is a untyped 'Callable' as a placeholder for such customizations until I figure out what the function signature should be (or maybe it will be a class, like ItemAction).