### PR TITLE
Add Game State to Quantum RPG

### DIFF
--- a/unitary/examples/quantum_rpg/ascii_art.py
+++ b/unitary/examples/quantum_rpg/ascii_art.py
@@ -1,6 +1,6 @@
 # ASCII art generated with font
 # DOOM by Frans P. de Vries <fpv@xymph.iaf.nl>  18 Jun 1996
-#based on Big by Glenn Chappell 4/93 -- based on Standard
+# based on Big by Glenn Chappell 4/93 -- based on Standard
 # figlet release 2.1 -- 12 Aug 1994
 TITLE_SCREEN = r"""
 ______  _                _             _____  _           _

--- a/unitary/examples/quantum_rpg/battle.py
+++ b/unitary/examples/quantum_rpg/battle.py
@@ -55,10 +55,9 @@ class Battle:
     ):
         self.player_side = state.party  # TODO: copy this
         self.enemy_side = enemy_side
-        self.game_state = state
-        self.file = self.game_state.file
+        self.file = game_state.file
         self.xp = xp
-        self.get_user_input = self.game_state.get_user_input
+        self.get_user_input = game_state.get_user_input
 
     def print_screen(self):
         """Prints a two-column output of the battle status.

--- a/unitary/examples/quantum_rpg/battle.py
+++ b/unitary/examples/quantum_rpg/battle.py
@@ -55,9 +55,9 @@ class Battle:
     ):
         self.player_side = state.party  # TODO: copy this
         self.enemy_side = enemy_side
-        self.file = game_state.file
+        self.file = state.file
         self.xp = xp
-        self.get_user_input = game_state.get_user_input
+        self.get_user_input = state.get_user_input
 
     def print_screen(self):
         """Prints a two-column output of the battle status.

--- a/unitary/examples/quantum_rpg/battle_test.py
+++ b/unitary/examples/quantum_rpg/battle_test.py
@@ -15,18 +15,21 @@
 import io
 import unitary.examples.quantum_rpg.battle as battle
 import unitary.examples.quantum_rpg.classes as classes
+import unitary.examples.quantum_rpg.game_state as game_state
 import unitary.examples.quantum_rpg.npcs as npcs
 
 
 def test_battle():
-    output = io.StringIO()
     c = classes.Analyst("Aaronson")
     e = npcs.Observer("watcher")
-    b = battle.Battle([c], [e], file=output)
-    b.take_player_turn(user_input=["s", "1", "1"])
+    state = game_state.GameState(
+        party=[c], user_input=["s", "1", "1"], file=io.StringIO()
+    )
+    b = battle.Battle(state, [e])
+    b.take_player_turn()
     b.take_npc_turn()
     assert (
-        output.getvalue().replace("\t", " ").strip()
+        state.file.getvalue().replace("\t", " ").strip()
         == r"""
 -----------------------------------------------
 Aaronson Analyst   watcher Observer
@@ -42,13 +45,15 @@ Observer watcher measures Aaronson at qubit Aaronson_1
 
 
 def test_bad_monster():
-    output = io.StringIO()
     c = classes.Analyst("Aaronson")
     e = npcs.Observer("watcher")
-    b = battle.Battle([c], [e], file=output)
-    b.take_player_turn(user_input=["s", "2", "1", "1"])
+    state = game_state.GameState(
+        party=[c], user_input=["s", "2", "1", "1"], file=io.StringIO()
+    )
+    b = battle.Battle(state, [e])
+    b.take_player_turn()
     assert (
-        output.getvalue().replace("\t", " ").strip()
+        state.file.getvalue().replace("\t", " ").strip()
         == r"""
 -----------------------------------------------
 Aaronson Analyst   watcher Observer
@@ -64,13 +69,15 @@ Sample result HealthPoint.HURT
 
 
 def test_bad_qubit():
-    output = io.StringIO()
     c = classes.Analyst("Aaronson")
     e = npcs.Observer("watcher")
-    b = battle.Battle([c], [e], file=output)
-    b.take_player_turn(user_input=["s", "1", "2"])
+    state = game_state.GameState(
+        party=[c], user_input=["s", "1", "2"], file=io.StringIO()
+    )
+    b = battle.Battle(state, [e])
+    b.take_player_turn()
     assert (
-        output.getvalue().replace("\t", " ").strip()
+        state.file.getvalue().replace("\t", " ").strip()
         == r"""
 -----------------------------------------------
 Aaronson Analyst   watcher Observer
@@ -85,13 +92,15 @@ watcher_2 is not an active qubit
 
 
 def test_battle_loop():
-    output = io.StringIO()
     c = classes.Analyst("Aaronson")
     e = npcs.Observer("watcher")
-    b = battle.Battle([c], [e], file=output)
-    assert b.loop(user_input=["s", "1", "1"]) == battle.BattleResult.PLAYERS_DOWN
+    state = game_state.GameState(
+        party=[c], user_input=["s", "1", "1"], file=io.StringIO()
+    )
+    b = battle.Battle(state, [e])
+    assert b.loop() == battle.BattleResult.PLAYERS_DOWN
     assert (
-        output.getvalue().replace("\t", " ").strip()
+        state.file.getvalue().replace("\t", " ").strip()
         == r"""
 -----------------------------------------------
 Aaronson Analyst   watcher Observer

--- a/unitary/examples/quantum_rpg/encounter.py
+++ b/unitary/examples/quantum_rpg/encounter.py
@@ -18,6 +18,7 @@ from typing import Optional, Sequence
 import random
 
 import unitary.examples.quantum_rpg.battle as battle
+import unitary.examples.quantum_rpg.game_state as game_state
 import unitary.examples.quantum_rpg.qaracter as qaracter
 import unitary.examples.quantum_rpg.xp_utils as xp_utils
 from typing import Sequence
@@ -48,9 +49,5 @@ class Encounter:
         """
         return random.random() < self.probability
 
-    def initiate(
-        self, players: Sequence[qaracter.Qaracter], file: Optional[io.IOBase] = None
-    ) -> battle.Battle:
-        if file:
-            return battle.Battle(players, self.enemies, file, xp=self.xp)
-        return battle.Battle(players, self.enemies, xp=self.xp)
+    def initiate(self, state: game_state.GameState) -> battle.Battle:
+        return battle.Battle(state, self.enemies, xp=self.xp)

--- a/unitary/examples/quantum_rpg/encounter_test.py
+++ b/unitary/examples/quantum_rpg/encounter_test.py
@@ -15,6 +15,7 @@
 import io
 import unitary.examples.quantum_rpg.battle as battle
 import unitary.examples.quantum_rpg.classes as classes
+import unitary.examples.quantum_rpg.game_state as game_state
 import unitary.examples.quantum_rpg.encounter as encounter
 import unitary.examples.quantum_rpg.npcs as npcs
 
@@ -32,16 +33,18 @@ def test_trigger():
 
 
 def test_encounter():
-    output = io.StringIO()
-    o = npcs.Observer("watcher")
-    e = encounter.Encounter([o], output)
-
     c = classes.Analyst("Aaronson")
-    b = e.initiate([c], output)
-    b.take_player_turn(user_input=["s", "1", "1"])
+    o = npcs.Observer("watcher")
+    state = game_state.GameState(
+        party=[c], user_input=["s", "1", "1"], file=io.StringIO()
+    )
+    e = encounter.Encounter([o])
+
+    b = e.initiate(state)
+    b.take_player_turn()
     b.take_npc_turn()
     assert (
-        output.getvalue().replace("\t", " ").strip()
+        state.file.getvalue().replace("\t", " ").strip()
         == r"""
 -----------------------------------------------
 Aaronson Analyst   watcher Observer

--- a/unitary/examples/quantum_rpg/game_state.py
+++ b/unitary/examples/quantum_rpg/game_state.py
@@ -21,6 +21,10 @@ import unitary.examples.quantum_rpg.input_helpers as input_helpers
 import unitary.examples.quantum_rpg.qaracter as qaracter
 
 
+_SAVE_DELIMITER = ";"
+_DICT_DELIMITER = ":"
+
+
 class GameState:
     def __init__(
         self,
@@ -44,7 +48,7 @@ class GameState:
         user_input: Optional[Sequence[str]] = None,
         file: io.IOBase = sys.stdout,
     ) -> "GameState":
-        lines = save_file.split(";")
+        lines = save_file.split(_SAVE_DELIMITER)
         current_location_label = lines[0]
         party: List[qaracter.Qaracter] = []
         num_party = int(lines[1])
@@ -57,9 +61,9 @@ class GameState:
         return cls(party, current_location_label, state_dict, user_input, file)
 
     def to_save_file(self) -> str:
-        s = f"{self.current_location_label};{len(self.party)};"
+        s = f"{self.current_location_label}{_SAVE_DELIMITER}{len(self.party)}{_SAVE_DELIMITER}"
         for p in self.party:
-            s += p.to_save_file() + ";"
+            s += p.to_save_file() + _SAVE_DELIMITER
         for k, v in self.state_dict.items():
-            s += f"{k}:{v};"
+            s += f"{k}{_DICT_DELIMITER}{v}{_SAVE_DELIMITER}"
         return s[:-1]

--- a/unitary/examples/quantum_rpg/game_state.py
+++ b/unitary/examples/quantum_rpg/game_state.py
@@ -1,0 +1,65 @@
+# Copyright 2023 The Unitary Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, List, Optional, Sequence
+
+import io
+import sys
+
+import unitary.examples.quantum_rpg.input_helpers as input_helpers
+import unitary.examples.quantum_rpg.qaracter as qaracter
+
+
+class GameState:
+    def __init__(
+        self,
+        party: List[qaracter.Qaracter],
+        current_location_label: str = "",
+        state_dict: Dict[str, str] = None,
+        user_input: Optional[Sequence[str]] = None,
+        file: io.IOBase = sys.stdout,
+    ):
+        self.party = party
+        self.current_location_label = current_location_label
+        self.state_dict = state_dict or {}
+        self.user_input = user_input
+        self.get_user_input = input_helpers.get_user_input_function(user_input)
+        self.file = file
+
+    @classmethod
+    def from_save_file(
+        cls,
+        save_file: str,
+        user_input: Optional[Sequence[str]] = None,
+        file: io.IOBase = sys.stdout,
+    ) -> "GameState":
+        lines = save_file.split(";")
+        current_location_label = lines[0]
+        party: List[qaracter.Qaracter] = []
+        num_party = int(lines[1])
+        for party_idx in range(2, 2 + num_party):
+            party.append(qaracter.Qaracter.from_save_file(lines[party_idx]))
+        state_dict = {}
+        for line in lines[2 + num_party :]:
+            dict_value = line.split(":")
+            state_dict[dict_value[0]] = dict_value[1]
+        return cls(party, current_location_label, state_dict, user_input, file)
+
+    def to_save_file(self) -> str:
+        s = f"{self.current_location_label};{len(self.party)};"
+        for p in self.party:
+            s += p.to_save_file() + ";"
+        for k, v in self.state_dict.items():
+            s += f"{k}:{v};"
+        return s[:-1]

--- a/unitary/examples/quantum_rpg/game_state_test.py
+++ b/unitary/examples/quantum_rpg/game_state_test.py
@@ -1,0 +1,53 @@
+# Copyright 2023 The Unitary Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unitary.alpha as alpha
+import unitary.examples.quantum_rpg.qaracter as qaracter
+import unitary.examples.quantum_rpg.game_state as game_state
+
+
+def test_serialization() -> None:
+    qar = qaracter.Qaracter(name="plato")
+    qar.add_hp()
+    qar.add_hp()
+    qar.add_hp()
+    qar.add_quantum_effect(alpha.Flip(), 1)
+    qar.add_quantum_effect(alpha.Phase(), 2)
+    qar.add_quantum_effect(alpha.Superposition(), 3)
+    qar2 = qaracter.Qaracter(name="aristotle")
+    qar2.add_hp()
+    qar2.add_quantum_effect(alpha.Flip(effect_fraction=0.25), 2)
+    qar2.add_quantum_effect(alpha.Phase(effect_fraction=0.125), 1)
+
+    state_dict = {"puzzle1": "complete", "puzzle2": "WIP"}
+    label = "quantum_lab1"
+
+    state = game_state.GameState(
+        party=[qar, qar2], state_dict=state_dict, current_location_label=label
+    )
+    serialized_str = state.to_save_file()
+    deserialized_state = game_state.GameState.from_save_file(serialized_str)
+
+    assert deserialized_state.current_location_label == label
+    assert deserialized_state.state_dict == state_dict
+    assert len(deserialized_state.party) == 2
+
+    deserialized_qar = deserialized_state.party[0]
+    assert deserialized_qar.name == qar.name
+    assert deserialized_qar.level == qar.level
+    assert deserialized_qar.circuit == qar.circuit
+    deserialized_qar2 = deserialized_state.party[1]
+    assert deserialized_qar2.name == qar2.name
+    assert deserialized_qar2.level == qar2.level
+    assert deserialized_qar2.circuit == qar2.circuit

--- a/unitary/examples/quantum_rpg/main_loop_test.py
+++ b/unitary/examples/quantum_rpg/main_loop_test.py
@@ -15,6 +15,7 @@
 import io
 import unitary.examples.quantum_rpg.classes as classes
 import unitary.examples.quantum_rpg.encounter as encounter
+import unitary.examples.quantum_rpg.game_state as game_state
 import unitary.examples.quantum_rpg.item as item
 import unitary.examples.quantum_rpg.main_loop as main_loop
 import unitary.examples.quantum_rpg.npcs as npcs
@@ -64,12 +65,12 @@ def test_parse_commands() -> None:
 
 
 def test_simple_main_loop() -> None:
-    output = io.StringIO()
     c = classes.Analyst("Mensing")
-    loop = main_loop.MainLoop([c], world.World(EXAMPLE_WORLD), output)
+    state = game_state.GameState(party=[c], user_input=["quit"], file=io.StringIO())
+    loop = main_loop.MainLoop(state=state, world=world.World(EXAMPLE_WORLD))
     loop.loop(user_input=["quit"])
     assert (
-        output.getvalue().replace("\t", " ").strip()
+        state.file.getvalue().replace("\t", " ").strip()
         == r"""
 Lab Entrance
 
@@ -81,12 +82,14 @@ Exits: east.
 
 
 def test_do_simple_move() -> None:
-    output = io.StringIO()
     c = classes.Analyst("Mensing")
-    loop = main_loop.MainLoop([c], world.World(EXAMPLE_WORLD), output)
-    loop.loop(user_input=["e", "read sign", "w", "quit"])
+    state = game_state.GameState(
+        party=[c], user_input=["e", "read sign", "w", "quit"], file=io.StringIO()
+    )
+    loop = main_loop.MainLoop(world.World(EXAMPLE_WORLD), state)
+    loop.loop()
     assert (
-        output.getvalue().replace("\t", " ").strip()
+        state.file.getvalue().replace("\t", " ").strip()
         == r"""
 Lab Entrance
 
@@ -114,12 +117,14 @@ Exits: east.
 
 
 def test_battle() -> None:
-    output = io.StringIO()
     c = classes.Analyst("Mensing")
-    loop = main_loop.MainLoop([c], world.World(EXAMPLE_WORLD), output)
-    loop.loop(user_input=["e", "south", "s", "1", "1", "quit"])
+    state = game_state.GameState(
+        party=[c], user_input=["e", "south", "s", "1", "1", "quit"], file=io.StringIO()
+    )
+    loop = main_loop.MainLoop(state=state, world=world.World(EXAMPLE_WORLD))
+    loop.loop()
     assert (
-        output.getvalue().replace("\t", " ").strip()
+        state.file.getvalue().replace("\t", " ").strip()
         == r"""
 Lab Entrance
 
@@ -160,12 +165,12 @@ Exits: north.
 
 
 def test_title_screen():
-    output = io.StringIO()
-    loop = main_loop.MainLoop([], world.World(EXAMPLE_WORLD), output)
+    state = game_state.GameState(party=[], user_input=[], file=io.StringIO())
+    loop = main_loop.MainLoop(state=state, world=world.World(EXAMPLE_WORLD))
     loop.print_title_screen()
 
     assert (
-        output.getvalue()
+        state.file.getvalue()
         == r"""
 ______  _                _             _____  _           _
 |  ___|(_)              | |           /  ___|| |         | |

--- a/unitary/examples/quantum_rpg/npcs_test.py
+++ b/unitary/examples/quantum_rpg/npcs_test.py
@@ -15,12 +15,14 @@
 import unitary.alpha as alpha
 import unitary.examples.quantum_rpg.battle as battle
 import unitary.examples.quantum_rpg.classes as classes
+import unitary.examples.quantum_rpg.game_state as game_state
 import unitary.examples.quantum_rpg.npcs as npcs
 
 
 def test_observer():
     qar = npcs.Observer(name="glasses")
     c = classes.Analyst("cat")
-    b = battle.Battle([c], [qar])
+    state = game_state.GameState(party=[c])
+    b = battle.Battle(state, [qar])
     assert qar.is_npc()
     assert qar.npc_action(b) == "Observer glasses measures cat at qubit cat_1"

--- a/unitary/examples/quantum_rpg/qaracter.py
+++ b/unitary/examples/quantum_rpg/qaracter.py
@@ -21,6 +21,7 @@ from unitary.examples.quantum_rpg import enums
 _GATE_DELIMITER = ","
 _FIELD_DELIMITER = "#"
 
+
 class Qaracter(alpha.QuantumWorld):
     """Base class for quantum RPG characters.
 
@@ -58,7 +59,7 @@ class Qaracter(alpha.QuantumWorld):
         self.level = 0
         self.add_hp()
         if _FIELD_DELIMITER in self.name:
-          raise ValueError('{_FIELD_DELIMITER} is not allowed as part of a name')
+            raise ValueError("{_FIELD_DELIMITER} is not allowed as part of a name")
 
     def is_npc(self) -> bool:
         """Returns Trus if a non-player or False if a player.
@@ -177,23 +178,23 @@ class Qaracter(alpha.QuantumWorld):
         for _ in range(level - 1):
             qar.add_hp()
         for line in lines[2:]:
-            gate_type=line[0]
+            gate_type = line[0]
             fields = line[1:].split(_GATE_DELIMITER)
-            exponent = float(fields[1])
-            qubit0 = int(fields[2])
-            qubit1 = int(fields[3]) if len(fields) > 3 else None
-            if fields[0] == "X":
+            exponent = float(fields[0])
+            qubit0 = int(fields[1])
+            qubit1 = int(fields[2]) if len(fields) > 3 else None
+            if gate_type == "X":
                 qar.add_quantum_effect(alpha.Flip(effect_fraction=exponent), qubit0)
-            elif fields[0] == "Z":
+            elif gate_type == "Z":
                 qar.add_quantum_effect(alpha.Phase(effect_fraction=exponent), qubit0)
-            elif fields[0] == "H":
+            elif gate_type == "H":
                 qar.add_quantum_effect(alpha.Superposition(), qubit0)
-            elif fields[0] == "S":
-                # TODO: add 2 qubit effects
-                pass
-            elif fields[0] == "I":
-                # TODO: add 2 qubit effects
-                pass
+            elif gate_type == "S":
+                # TODO: effect_fraction
+                qar.add_quantum_effect(alpha.Move(), qubit0, qubit1)
+            elif gate_type == "I":
+                # TODO: effect_fraction
+                qar.add_quantum_effect(alpha.PhasedMove(), qubit0, qubit1)
         return qar
 
     def to_save_file(self) -> str:
@@ -203,15 +204,21 @@ class Qaracter(alpha.QuantumWorld):
             qubit0 = int(op.qubits[0].name[prefix:])
             qubit1 = int(op.qubits[1].name[prefix:]) if len(op.qubits) > 1 else None
             if isinstance(op.gate, cirq.XPowGate):
-                s += f"X{op.gate.exponent:3f}{_GATE_DELIMITER}{qubit0}{_FIELD_DELIMITER}"
+                s += (
+                    f"X{op.gate.exponent:3f}{_GATE_DELIMITER}{qubit0}{_FIELD_DELIMITER}"
+                )
             elif isinstance(op.gate, cirq.ZPowGate):
-                s += f"Z{op.gate.exponent:3f}{_GATE_DELIMITER}{qubit0}{_FIELD_DELIMITER}"
+                s += (
+                    f"Z{op.gate.exponent:3f}{_GATE_DELIMITER}{qubit0}{_FIELD_DELIMITER}"
+                )
             elif isinstance(op.gate, cirq.HPowGate):
-                s += f"H{op.gate.exponent:3f}{_GATE_DELIMITER}{qubit0}{_FIELD_DELIMITER}"
+                s += (
+                    f"H{op.gate.exponent:3f}{_GATE_DELIMITER}{qubit0}{_FIELD_DELIMITER}"
+                )
             elif isinstance(op.gate, cirq.SwapPowGate):
                 s += f"S{op.gate.exponent:3f}{_GATE_DELIMITER}"
                 s += f"{qubit0}{_GATE_DELIMITER}{qubit1}{_FIELD_DELIMITER}"
-            elif isinstance(op.gate, cirq.SwapPowGate):
+            elif isinstance(op.gate, cirq.ISwapPowGate):
                 s += f"I{op.gate.exponent:3f}{_GATE_DELIMITER}"
                 s += f"{qubit0}{_GATE_DELIMITER}{qubit1}{_FIELD_DELIMITER}"
         return s[:-1]

--- a/unitary/examples/quantum_rpg/qaracter_test.py
+++ b/unitary/examples/quantum_rpg/qaracter_test.py
@@ -149,3 +149,20 @@ def test_even_hp_qar() -> None:
     assert not qar.is_down()
     assert qar.is_escaped()
     assert not qar.is_active()
+
+
+def test_serialization() -> None:
+    qar = qaracter.Qaracter(name="curie")
+    qar.add_hp()
+    qar.add_hp()
+    qar.add_hp()
+    qar.add_quantum_effect(alpha.Flip(), 1)
+    qar.add_quantum_effect(alpha.Phase(), 2)
+    qar.add_quantum_effect(alpha.Superposition(), 3)
+    qar.add_quantum_effect(alpha.Flip(effect_fraction=0.25), 2)
+    qar.add_quantum_effect(alpha.Phase(effect_fraction=0.125), 1)
+    serialized_str = qar.to_save_file()
+    deserialized_qar = qaracter.Qaracter.from_save_file(serialized_str)
+    assert deserialized_qar.name == qar.name
+    assert deserialized_qar.level == qar.level
+    assert deserialized_qar.circuit == qar.circuit

--- a/unitary/examples/quantum_rpg/xp_utils.py
+++ b/unitary/examples/quantum_rpg/xp_utils.py
@@ -19,6 +19,7 @@ import random
 import sys
 
 import unitary.alpha as alpha
+import unitary.examples.quantum_rpg.game_state as game_state
 import unitary.examples.quantum_rpg.input_helpers as input_helpers
 import unitary.examples.quantum_rpg.qaracter as qaracter
 
@@ -47,45 +48,42 @@ class EncounterXp:
 
 
 def award_xp(
-    party: Sequence[qaracter.Qaracter],
+    state: game_state.GameState,
     xp: Optional[EncounterXp],
-    user_input: Optional[Sequence[str]],
-    file: io.IOBase = sys.stdout,
 ):
     """Prompt user to choose a qaracter to award XP to."""
     if not xp:
         return
-    get_user_input = input_helpers.get_user_input_function(user_input)
-    print("You have been awarded XP!", file=file)
+    print("You have been awarded XP!", file=state.file)
     effect_list = xp.choose()
     for effect in effect_list:
-        print(f"  {effect}", file=file)
-    print("", file=file)
+        print(f"  {effect}", file=state.file)
+    print("", file=state.file)
     for effect in effect_list:
         num_qubits = effect.num_objects() or 1
         eligible_party = [
-            qar for qar in party if len(qar.active_qubits()) >= num_qubits
+            qar for qar in state.party if len(qar.active_qubits()) >= num_qubits
         ]
         if not eligible_party:
-            print(f"Qaracters are not high-enough level for {effect}!", file=file)
+            print(f"Qaracters are not high-enough level for {effect}!", file=state.file)
             continue
-        print(f"Choose the qaracter to add the {effect} to:", file=file)
+        print(f"Choose the qaracter to add the {effect} to:", file=state.file)
         for idx, qar in enumerate(eligible_party):
-            print(f"{idx+1}) {qar.name}", file=file)
+            print(f"{idx+1}) {qar.name}", file=state.file)
         qar_choice = input_helpers.get_user_input_number(
-            get_user_input, ">", len(eligible_party)
+            state.get_user_input, ">", len(eligible_party)
         )
         qar = eligible_party[qar_choice - 1]
-        print("Current qaracter sheet:", file=file)
-        print(qar.circuit, file=file)
+        print("Current qaracter sheet:", file=state.file)
+        print(qar.circuit, file=state.file)
         qubit_list = list(qar.active_qubits())
         qubit_choices = []
         for qubit_num in range(num_qubits):
-            print(f"Choose qubit {qubit_num} for {effect}:", file=file)
+            print(f"Choose qubit {qubit_num} for {effect}:", file=state.file)
             for idx, q in enumerate(qubit_list):
-                print(f"{idx+1}) {q}", file=file)
+                print(f"{idx+1}) {q}", file=state.file)
             choice = input_helpers.get_user_input_number(
-                get_user_input, ">", len(qubit_list)
+                state.get_user_input, ">", len(qubit_list)
             )
             qubit_choices.append(qar.get_hp(qubit_list[choice - 1]))
         effect(*qubit_choices)

--- a/unitary/examples/quantum_rpg/xp_utils_test.py
+++ b/unitary/examples/quantum_rpg/xp_utils_test.py
@@ -18,6 +18,7 @@ import cirq
 
 import unitary.alpha as alpha
 import unitary.examples.quantum_rpg.classes as classes
+import unitary.examples.quantum_rpg.game_state as game_state
 import unitary.examples.quantum_rpg.xp_utils as xp_utils
 
 
@@ -41,13 +42,13 @@ def test_choose():
 
 
 def test_award_xp():
-    output = io.StringIO()
     c = classes.Analyst("wizard")
+    state = game_state.GameState(party=[c], user_input=["1", "1"], file=io.StringIO())
     enc = xp_utils.EncounterXp([[alpha.Superposition()]])
-    xp_utils.award_xp([c], enc, ["1", "1"], output)
+    xp_utils.award_xp(state, enc)
     assert c.circuit == cirq.Circuit(cirq.H(cirq.NamedQubit("wizard_1")))
     assert (
-        output.getvalue()
+        state.file.getvalue()
         == """You have been awarded XP!
   Superposition
 
@@ -62,16 +63,18 @@ Choose qubit 0 for Superposition:
 
 
 def test_award_xp_multi_qubit_gate():
-    output = io.StringIO()
     c = classes.Analyst("wizard")
     c.add_hp()
+    state = game_state.GameState(
+        party=[c], user_input=["1", "1", "2"], file=io.StringIO()
+    )
     enc = xp_utils.EncounterXp([[alpha.Move()]])
-    xp_utils.award_xp([c], enc, ["1", "1", "2"], output)
+    xp_utils.award_xp(state, enc)
     assert c.circuit == cirq.Circuit(
         cirq.SWAP(cirq.NamedQubit("wizard_1"), cirq.NamedQubit("wizard_2"))
     )
     assert (
-        output.getvalue()
+        state.file.getvalue()
         == """You have been awarded XP!
   Move
 
@@ -90,13 +93,15 @@ Choose qubit 1 for Move:
 
 
 def test_qaracter_not_high_enough():
-    output = io.StringIO()
     c = classes.Analyst("wizard")
     enc = xp_utils.EncounterXp([[alpha.Move()]])
-    xp_utils.award_xp([c], enc, ["1", "1", "2"], output)
+    state = game_state.GameState(
+        party=[c], user_input=["1", "1", "2"], file=io.StringIO()
+    )
+    xp_utils.award_xp(state, enc)
     assert c.circuit == cirq.Circuit()
     assert (
-        output.getvalue()
+        state.file.getvalue()
         == """You have been awarded XP!
   Move
 


### PR DESCRIPTION
- Add a game state object that contains state for the main loop.
- This allows us to store the user_input and output source, so we don't have to pass them around all over.
- This also adds a state_dict where we can store random state, so that we can have some puzzles with state.
- This also contains a serialization mechanism, so we can have a way to generate 1990's style game codes.