### PR TITLE
Quantum RPG: Allow multi-qubit effects in qaracters

### DIFF
--- a/unitary/examples/quantum_rpg/qaracter.py
+++ b/unitary/examples/quantum_rpg/qaracter.py
@@ -101,12 +101,14 @@ class Qaracter(alpha.QuantumWorld):
             if self.quantum_object_name(i) not in self.health_status
         ]
 
-    def add_quantum_effect(self, effect, quantum_name: Union[int, str]):
+    def add_quantum_effect(self, effect, *quantum_names: Union[int, str]):
         """Adds a Quantum Effect to a specific quantum object."""
-        if isinstance(quantum_name, int):
-            quantum_name = self.quantum_object_name(quantum_name)
-        hp_obj = self.get_hp(quantum_name)
-        effect(hp_obj)
+        hp_objs = []
+        for quantum_name in quantum_names:
+            if isinstance(quantum_name, int):
+                quantum_name = self.quantum_object_name(quantum_name)
+            hp_objs.append(self.get_hp(quantum_name))
+        effect(*hp_objs)
 
     @property
     def damage(self) -> int:

--- a/unitary/examples/quantum_rpg/qaracter_test.py
+++ b/unitary/examples/quantum_rpg/qaracter_test.py
@@ -34,6 +34,17 @@ def test_qubit_getters_and_effects() -> None:
     assert qar.sample(obj_name, save_result=False) == enums.HealthPoint.HEALTHY
 
 
+def test_multi_qubit_effects() -> None:
+    qar = qaracter.Qaracter(name="lovelace")
+    qar.add_hp()
+    qar.add_quantum_effect(alpha.Flip(), 1)
+    qar.add_quantum_effect(alpha.Move(), 1, 2)
+    q1 = qar.quantum_object_name(1)
+    q2 = qar.quantum_object_name(2)
+    assert qar.sample(q1, save_result=False) == enums.HealthPoint.HURT
+    assert qar.sample(q2, save_result=False) == enums.HealthPoint.HEALTHY
+
+
 def test_save_result() -> None:
     qar = qaracter.Qaracter(name="bohr")
     obj_name = qar.quantum_object_name(1)


### PR DESCRIPTION
- Currently, add_quantum_effect only takes one qubit.
- This allows you to pass a variable amount of qubits into the function so that we can add two-qubit gates.