### PR TITLE
[Quantum RPG] Copy qaracters during battles

### DIFF
--- a/unitary/alpha/quantum_world.py
+++ b/unitary/alpha/quantum_world.py
@@ -82,7 +82,11 @@ class QuantumWorld:
             new_objects.append(new_obj)
             if obj in self.post_selection:
                 new_post_selection[new_obj] = self.post_selection[obj]
-        new_obj = self.__class__(new_objects, self.sampler, self.compile_to_qubits)
+        new_obj = self.__class__(
+            objects=new_objects,
+            sampler=self.sampler,
+            compile_to_qubits=self.compile_to_qubits,
+        )
         new_obj.circuit = self.circuit.copy()
         new_obj.ancilla_names = self.ancilla_names.copy()
         new_obj.effect_history = [

--- a/unitary/examples/quantum_rpg/battle.py
+++ b/unitary/examples/quantum_rpg/battle.py
@@ -53,7 +53,7 @@ class Battle:
         enemy_side: List[Qaracter],
         xp: Optional[EncounterXp] = None,
     ):
-        self.player_side = state.party  # TODO: copy this
+        self.player_side = [qar.copy() for qar in state.party]
         self.enemy_side = enemy_side
         self.file = state.file
         self.xp = xp

--- a/unitary/examples/quantum_rpg/encounter.py
+++ b/unitary/examples/quantum_rpg/encounter.py
@@ -49,5 +49,14 @@ class Encounter:
         """
         return random.random() < self.probability
 
+    def copy(self) -> "Encounter":
+        enemies_copy = [qar.copy() for qar in self.enemies]
+        return Encounter(
+            enemies=enemies_copy,
+            probability=self.probability,
+            description=self.description,
+            xp=self.xp,
+        )
+
     def initiate(self, state: game_state.GameState) -> battle.Battle:
         return battle.Battle(state, self.enemies, xp=self.xp)

--- a/unitary/examples/quantum_rpg/encounter_test.py
+++ b/unitary/examples/quantum_rpg/encounter_test.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 import io
+import unitary.alpha as alpha
 import unitary.examples.quantum_rpg.battle as battle
 import unitary.examples.quantum_rpg.classes as classes
 import unitary.examples.quantum_rpg.game_state as game_state
 import unitary.examples.quantum_rpg.encounter as encounter
 import unitary.examples.quantum_rpg.npcs as npcs
+import unitary.examples.quantum_rpg.xp_utils as xp_utils
 
 
 def test_trigger():
@@ -57,3 +59,20 @@ Sample result HealthPoint.HURT
 Observer watcher measures Aaronson at qubit Aaronson_1
 """.strip()
     )
+
+
+def test_copy():
+    o = npcs.Observer("watcher")
+    xp = xp_utils.EncounterXp([[alpha.Flip()]], weights=[1])
+    e = encounter.Encounter([o], probability=0.75, description="Tester", xp=xp)
+    e2 = e.copy()
+    assert len(e.enemies) == len(e2.enemies)
+    assert e.enemies[0] is not e2.enemies[0]
+    qar = e.enemies[0]
+    qar2 = e2.enemies[0]
+    assert qar.circuit == qar2.circuit
+    assert qar.name == qar2.name
+    assert qar.level == qar2.level
+    assert e.probability == e2.probability
+    assert e.description == e2.description
+    assert e.xp == e2.xp

--- a/unitary/examples/quantum_rpg/qaracter.py
+++ b/unitary/examples/quantum_rpg/qaracter.py
@@ -52,8 +52,8 @@ class Qaracter(alpha.QuantumWorld):
         name: name of this character as a string.
     """
 
-    def __init__(self, name: str):
-        super().__init__()
+    def __init__(self, name: str = "", **kwargs):
+        super().__init__(**kwargs)
         self.name = name
         self.health_status: Dict[alpha.QuantumObject, int] = {}
         self.level = 0
@@ -115,6 +115,13 @@ class Qaracter(alpha.QuantumWorld):
                 quantum_name = self.quantum_object_name(quantum_name)
             hp_objs.append(self.get_hp(quantum_name))
         effect(*hp_objs)
+
+    def copy(self) -> "Qaracter":
+        new_obj = super().copy()
+        new_obj.name = self.name
+        new_obj.health_status = self.health_status
+        new_obj.level = self.level
+        return new_obj
 
     @property
     def damage(self) -> int:

--- a/unitary/examples/quantum_rpg/qaracter_test.py
+++ b/unitary/examples/quantum_rpg/qaracter_test.py
@@ -45,6 +45,20 @@ def test_multi_qubit_effects() -> None:
     assert qar.sample(q2, save_result=False) == enums.HealthPoint.HEALTHY
 
 
+def test_copy() -> None:
+    qar = qaracter.Qaracter(name="lovelace")
+    qar.add_hp()
+    qar.add_quantum_effect(alpha.Flip(), 1)
+    qar.add_quantum_effect(alpha.Move(), 1, 2)
+    qar2 = qar.copy()
+    assert qar.circuit == qar2.circuit
+    assert qar.name == qar2.name
+    assert qar.level == qar2.level
+    # Assert the copy evolves separately
+    qar2.add_hp()
+    assert qar.level != qar2.level
+
+
 def test_save_result() -> None:
     qar = qaracter.Qaracter(name="bohr")
     obj_name = qar.quantum_object_name(1)


### PR DESCRIPTION
- Copy the party when entering a battle so that temporary battle effects, like gates added to the circuit or measurements, do not affect the qaracters once the battle is over.