### PR TITLE
[Quantum RPG] Add effect fraction to save file

### DIFF
--- a/unitary/examples/quantum_rpg/qaracter.py
+++ b/unitary/examples/quantum_rpg/qaracter.py
@@ -182,7 +182,7 @@ class Qaracter(alpha.QuantumWorld):
             fields = line[1:].split(_GATE_DELIMITER)
             exponent = float(fields[0])
             qubit0 = int(fields[1])
-            qubit1 = int(fields[2]) if len(fields) > 3 else None
+            qubit1 = int(fields[2]) if len(fields) > 2 else None
             if gate_type == "X":
                 qar.add_quantum_effect(alpha.Flip(effect_fraction=exponent), qubit0)
             elif gate_type == "Z":
@@ -190,11 +190,13 @@ class Qaracter(alpha.QuantumWorld):
             elif gate_type == "H":
                 qar.add_quantum_effect(alpha.Superposition(), qubit0)
             elif gate_type == "S":
-                # TODO: effect_fraction
-                qar.add_quantum_effect(alpha.Move(), qubit0, qubit1)
+                qar.add_quantum_effect(
+                    alpha.Move(effect_fraction=exponent), qubit0, qubit1
+                )
             elif gate_type == "I":
-                # TODO: effect_fraction
-                qar.add_quantum_effect(alpha.PhasedMove(), qubit0, qubit1)
+                qar.add_quantum_effect(
+                    alpha.PhasedMove(effect_fraction=exponent), qubit0, qubit1
+                )
         return qar
 
     def to_save_file(self) -> str:

--- a/unitary/examples/quantum_rpg/qaracter_test.py
+++ b/unitary/examples/quantum_rpg/qaracter_test.py
@@ -164,14 +164,15 @@ def test_even_hp_qar() -> None:
 
 def test_serialization() -> None:
     qar = qaracter.Qaracter(name="curie")
-    qar.add_hp()
-    qar.add_hp()
-    qar.add_hp()
+    for _ in range(7):
+        qar.add_hp()
     qar.add_quantum_effect(alpha.Flip(), 1)
     qar.add_quantum_effect(alpha.Phase(), 2)
     qar.add_quantum_effect(alpha.Superposition(), 3)
     qar.add_quantum_effect(alpha.Flip(effect_fraction=0.25), 2)
     qar.add_quantum_effect(alpha.Phase(effect_fraction=0.125), 1)
+    qar.add_quantum_effect(alpha.Split(), 1, 4, 5)
+    qar.add_quantum_effect(alpha.PhasedSplit(), 3, 6, 7)
     serialized_str = qar.to_save_file()
     deserialized_qar = qaracter.Qaracter.from_save_file(serialized_str)
     assert deserialized_qar.name == qar.name


### PR DESCRIPTION
- This adds effect fraction to two qubit operations for save files
- Also adds a test for two-qubit operations (note that Split/PhasedSplit) involve a sqrt SWAP/ISWAP so this tests effect fraction)