### PR TITLE
[Quantum RPG] Fix a few bugs and issues

### DIFF
--- a/unitary/examples/quantum_rpg/final_state_preparation/classical_realm.py
+++ b/unitary/examples/quantum_rpg/final_state_preparation/classical_realm.py
@@ -56,11 +56,11 @@ RICHARD = Item(
             TALK,
             ["richard", "feynmann", "physicist"],
             (
-                "Richard excitedly talks, as if continuing a lecture in progress:\n"
-                "'Modern computers are truly powerful and wondrous, but if want to\n"
-                "truly understand nature and the laws of the world around, we are\n"
+                "Richard speaks excitedly, as if continuing a lecture in progress:\n"
+                "'Modern computers are truly powerful and wondrous, but if we want to\n"
+                "truly understand nature and the laws of the world around us, we are\n"
                 "going to need a much more powerful device.\n"
-                "Nature isn't classical, dammit, and if you want to make a simulation\n"
+                "Nature isn't classical, damnit, and if you want to make a simulation\n"
                 "of nature, you'd better make it quantum mechanical!  By golly, it's\n"
                 "a wonderful problem, but it doesn't look easy.  I would start by\n"
                 "searching for an abandoned nuclear lab on the ruins of Oxtail university.'\n"
@@ -142,13 +142,13 @@ DAVID = Item(
             ["david", "man", "deutsch"],
             (
                 "David turns to you.  'Welcome to Oxtail University.' David says.\n"
-                "'You seems to have come at an interesting time.  Our university was\n"
+                "'You seem to have come at an interesting time.  Our university was\n"
                 "founded here at the forefront of the quantum realm, and we have been\n"
-                "researching quantum computation in search of a computational thoery of\n"
+                "researching quantum computation in search of a computational theory of\n"
                 "everything.  Unfortunately, our university has been less of an invariant\n"
                 "than hoped.  Quantum fluctuations and errors have infiltrated this whole\n"
-                "place, and we are in dire straits I fear.  Look for my student Artur.\n"
-                "If he still survives, he will be in the communications outpust.i'\n"
+                "place, and we are in dire straits, I fear.  Look for my student Artur.\n"
+                "If he is still alive, he will be in the communications outpust.'\n"
             ),
         )
     ],
@@ -455,9 +455,9 @@ CLASSICAL_REALM = [
         label="quad3",
         title="Lone Monument",
         description=(
-            "A statue stands in this corner of campus dedicated to Stephen Hawking,\n"
-            "one of the pioneers of theoretical physics.  A pool of quantum foam\n"
-            "surrounds the statue, and nearby, an unnerving tenebrous spot reminiscent\n"
+            "A statue dedicated to Stephen Hawking stands in this corner of the campus,\n"
+            "He was one of the pioneers of theoretical physics.  A pool of quantum foam\n"
+            "surrounds the statue and, nearby, an unnerving tenebrous spot reminiscent\n"
             "of the black holes Hawking was famous for casts a dark shadow on the wall."
         ),
         items=[],

--- a/unitary/examples/quantum_rpg/final_state_preparation/classical_realm.py
+++ b/unitary/examples/quantum_rpg/final_state_preparation/classical_realm.py
@@ -56,14 +56,14 @@ RICHARD = Item(
             TALK,
             ["richard", "feynmann", "physicist"],
             (
-                "Richard excitedly talks, as if continuing a lecture in progress.\n"
-                "Modern computers are truly powerful and wondrous, but if want to\n"
+                "Richard excitedly talks, as if continuing a lecture in progress:\n"
+                "'Modern computers are truly powerful and wondrous, but if want to\n"
                 "truly understand nature and the laws of the world around, we are\n"
                 "going to need a much more powerful device.\n"
                 "Nature isn't classical, dammit, and if you want to make a simulation\n"
                 "of nature, you'd better make it quantum mechanical!  By golly, it's\n"
                 "a wonderful problem, but it doesn't look easy.  I would start by\n"
-                "searching for an abandoned nuclear lab on the ruins of Oxtail university.\n"
+                "searching for an abandoned nuclear lab on the ruins of Oxtail university.'\n"
             ),
         )
     ],
@@ -141,14 +141,14 @@ DAVID = Item(
             TALK,
             ["david", "man", "deutsch"],
             (
-                "David turns to you.  'Welcome to Oxtail University.'\n"
+                "David turns to you.  'Welcome to Oxtail University.' David says.\n"
                 "'You seems to have come at an interesting time.  Our university was\n"
                 "founded here at the forefront of the quantum realm, and we have been\n"
                 "researching quantum computation in search of a computational thoery of\n"
                 "everything.  Unfortunately, our university has been less of an invariant\n"
                 "than hoped.  Quantum fluctuations and errors have infiltrated this whole\n"
                 "place, and we are in dire straits I fear.  Look for my student Artur.\n"
-                "If he still survives, he will be in the communications outpust.\n"
+                "If he still survives, he will be in the communications outpust.i'\n"
             ),
         )
     ],
@@ -163,7 +163,7 @@ ARTUR = Item(
             (
                 "Artur stands up tall and address you.  'We have lost contact\n"
                 "with our field researchers in the quantum realm.  They were exploring\n"
-                "techniques of communicating in the quantum realm.  If you can find them,\n"
+                "techniques of communicating using quantum states.  If you can find them,\n"
                 "they may be able to help figure out a way to stop the quantum errors\n"
                 "that are destroying our campus.'\n"
             ),
@@ -455,7 +455,7 @@ CLASSICAL_REALM = [
         label="quad3",
         title="Lone Monument",
         description=(
-            "A statue stands in this corner of campus dedicated to Stephen Hawking,"
+            "A statue stands in this corner of campus dedicated to Stephen Hawking,\n"
             "one of the pioneers of theoretical physics.  A pool of quantum foam\n"
             "surrounds the statue, and nearby, an unnerving tenebrous spot reminiscent\n"
             "of the black holes Hawking was famous for casts a dark shadow on the wall."
@@ -612,7 +612,6 @@ CLASSICAL_REALM = [
             "area.  The sterile white walls, impeccably clean and illuminated by the warm\n"
             "glow of recessed lights, creates an atmosphere of precision and meticulousness.\n"
             "A low hum of machinery comes from a larger room to the east.\n"
-            "A plan for this room, who needs one?"
         ),
         items=[],
         exits={Direction.WEST: "quad6", Direction.EAST: "nmr_lab2"},
@@ -635,7 +634,7 @@ CLASSICAL_REALM = [
         label="nmr_lab3",
         title="Atop the NMR Spectrometer",
         description=(
-            "Yoiu stand on a narrow walk way that circles around the massive\n"
+            "You stand on a narrow walk way that circles around the massive\n"
             "spectrometer.  From up here, you can see the entirety of the lab\n"
             "supporting the NMR research effort.  Wires and cables lead from\n"
             "the machine up to the ceiling and snake outward, connecting to all\n"

--- a/unitary/examples/quantum_rpg/main_loop.py
+++ b/unitary/examples/quantum_rpg/main_loop.py
@@ -85,7 +85,7 @@ class MainLoop:
 
                         if result == battle.BattleResult.PLAYERS_WON:
                             awarded_xp = current_battle.xp
-                            xp_utils.award_xp(self.party, awarded_xp)
+                            xp_utils.award_xp(self.game_state, awarded_xp)
                         break
                 if result is not None:
                     # Reprint location description now that encounter is over.

--- a/unitary/examples/quantum_rpg/npcs.py
+++ b/unitary/examples/quantum_rpg/npcs.py
@@ -91,7 +91,7 @@ class BlueFoam(Npc):
 
     def act_on_enemy_qubit(self, enemy_qubit, action_choice, **kwargs) -> str:
         if action_choice > 0.2:
-            slime = kwargs["slime"] or random.randint(0, 250) / 1000.0
+            slime = kwargs.get("slime") or random.randint(0, 250) / 1000.0
             alpha.Flip(effect_fraction=slime)(enemy_qubit)
             return f"{self.display_name} slimes {enemy_qubit.name} for {slime:0.3f}."
         else:
@@ -107,7 +107,7 @@ class GreenFoam(Npc):
 
     def act_on_enemy_qubit(self, enemy_qubit, action_choice, **kwargs) -> str:
         if action_choice > 0.2:
-            slime = kwargs["slime"] or random.randint(0, 250) / 1000.0
+            slime = kwargs.get("slime") or random.randint(0, 250) / 1000.0
             alpha.Phase(effect_fraction=slime)(enemy_qubit)
             return (
                 f"{self.display_name} oozes {enemy_qubit.name} for {slime:0.3f} phase."
@@ -129,7 +129,7 @@ class RedFoam(Npc):
 
     def act_on_enemy_qubit(self, enemy_qubit, action_choice, **kwargs) -> str:
         if action_choice > 0.2:
-            slime = kwargs["slime"] or random.randint(0, 350) / 1000.0
+            slime = kwargs.get("slime") or random.randint(0, 350) / 1000.0
             alpha.Flip(effect_fraction=slime)(enemy_qubit)
             return f"{self.display_name} slimes {enemy_qubit.name} for {slime:0.3f}."
         else:

--- a/unitary/examples/quantum_rpg/npcs_test.py
+++ b/unitary/examples/quantum_rpg/npcs_test.py
@@ -51,6 +51,8 @@ def test_green_foam():
     assert qar.is_npc()
     msg = qar.act_on_enemy_qubit(c.get_hp("person_1"), 0.1)
     assert msg == "GreenFoam bubbles measures person_1 as HURT."
+    msg = qar.act_on_enemy_qubit(c.get_hp("person_1"), 0.3)
+    assert "GreenFoam bubbles oozes person_1 for " in msg
     msg = qar.act_on_enemy_qubit(c.get_hp("person_1"), 0.3, slime=0.25)
     assert msg == "GreenFoam bubbles oozes person_1 for 0.250 phase."
 
@@ -64,6 +66,8 @@ def test_red_foam():
     assert qar.is_npc()
     msg = qar.act_on_enemy_qubit(c.get_hp("person_1"), 0.1)
     assert msg == "RedFoam bubbles measures person_1 as HURT."
+    msg = qar.act_on_enemy_qubit(c.get_hp("person_1"), 0.3)
+    assert "RedFoam bubbles slimes person_1 for " in msg
     msg = qar.act_on_enemy_qubit(c.get_hp("person_1"), 0.3, slime=0.25)
     assert msg == "RedFoam bubbles slimes person_1 for 0.250."
 


### PR DESCRIPTION
Fix a few bugs and issues found when running the RPG game.

- Slime parameter is mainly used for deterministic unit tests.
However, if not specified, it would generate a KeyError.
Change to get() to avoid this exception.
- main loop should pass game state to award XP and not party.
- Tweak a few descriptions that had typos or looked funny.