### PR TITLE
[Quantum RPG] Add help and descriptions to qaracter actions

### DIFF
--- a/unitary/examples/quantum_rpg/battle.py
+++ b/unitary/examples/quantum_rpg/battle.py
@@ -113,9 +113,15 @@ class Battle:
                 print(f"{current_player.name} is DOWN!", file=self.file)
                 continue
             actions = current_player.actions()
-            for key in actions:
-                print(key, file=self.file)
-            action = self.get_user_input("Choose your action: ")
+            descriptions = current_player.action_descriptions()
+            for key in sorted(actions):
+                print(f"{key}) {descriptions[key]}.", file=self.file)
+            print("h) Help.", file=self.file)
+            action = "h"
+            while action == "h":
+                action = self.get_user_input("Choose your action: ")
+                if action == "h":
+                    print(current_player.help(), file=self.file)
             if action in current_player.actions():
                 monster = (
                     input_helpers.get_user_input_number(

--- a/unitary/examples/quantum_rpg/battle_test.py
+++ b/unitary/examples/quantum_rpg/battle_test.py
@@ -23,7 +23,7 @@ def test_battle():
     c = classes.Analyst("Aaronson")
     e = npcs.Observer("watcher")
     state = game_state.GameState(
-        party=[c], user_input=["s", "1", "1"], file=io.StringIO()
+        party=[c], user_input=["m", "1", "1"], file=io.StringIO()
     )
     b = battle.Battle(state, [e])
     b.take_player_turn()
@@ -36,10 +36,9 @@ Aaronson Analyst   watcher Observer
 1QP (0|1> 0|0> 1?)   1QP (0|1> 0|0> 1?)
 -----------------------------------------------
 Aaronson turn:
-s
-m
-Sample result HealthPoint.HURT
-Observer watcher measures Aaronson_1 as HURT.
+m) Measure enemy qubit.
+h) Help.
+watcher is DOWN!
 """.strip()
     )
 
@@ -48,7 +47,7 @@ def test_bad_monster():
     c = classes.Analyst("Aaronson")
     e = npcs.Observer("watcher")
     state = game_state.GameState(
-        party=[c], user_input=["s", "2", "1", "1"], file=io.StringIO()
+        party=[c], user_input=["m", "2", "1", "1"], file=io.StringIO()
     )
     b = battle.Battle(state, [e])
     b.take_player_turn()
@@ -60,10 +59,9 @@ Aaronson Analyst   watcher Observer
 1QP (0|1> 0|0> 1?)   1QP (0|1> 0|0> 1?)
 -----------------------------------------------
 Aaronson turn:
-s
-m
+m) Measure enemy qubit.
+h) Help.
 Invalid number selected.
-Sample result HealthPoint.HURT
 """.strip()
     )
 
@@ -84,9 +82,8 @@ Aaronson Analyst   watcher Observer
 1QP (0|1> 0|0> 1?)   1QP (0|1> 0|0> 1?)
 -----------------------------------------------
 Aaronson turn:
-s
-m
-watcher_2 is not an active qubit
+m) Measure enemy qubit.
+h) Help.
 """.strip()
     )
 
@@ -95,10 +92,10 @@ def test_battle_loop():
     c = classes.Analyst("Aaronson")
     e = npcs.Observer("watcher")
     state = game_state.GameState(
-        party=[c], user_input=["s", "1", "1"], file=io.StringIO()
+        party=[c], user_input=["m", "1", "1"], file=io.StringIO()
     )
     b = battle.Battle(state, [e])
-    assert b.loop() == battle.BattleResult.PLAYERS_DOWN
+    assert b.loop() == battle.BattleResult.PLAYERS_WON
     assert (
         state.file.getvalue().replace("\t", " ").strip()
         == r"""
@@ -107,9 +104,32 @@ Aaronson Analyst   watcher Observer
 1QP (0|1> 0|0> 1?)   1QP (0|1> 0|0> 1?)
 -----------------------------------------------
 Aaronson turn:
-s
-m
-Sample result HealthPoint.HURT
-Observer watcher measures Aaronson_1 as HURT.
+m) Measure enemy qubit.
+h) Help.
+""".strip()
+    )
+
+
+def test_battle_help():
+    c = classes.Analyst("Aaronson")
+    e = npcs.Observer("watcher")
+    state = game_state.GameState(
+        party=[c], user_input=["h", "m", "1", "1"], file=io.StringIO()
+    )
+    b = battle.Battle(state, [e])
+    assert b.loop() == battle.BattleResult.PLAYERS_WON
+    assert (
+        state.file.getvalue().replace("\t", " ").strip()
+        == r"""
+-----------------------------------------------
+Aaronson Analyst   watcher Observer
+1QP (0|1> 0|0> 1?)   1QP (0|1> 0|0> 1?)
+-----------------------------------------------
+Aaronson turn:
+m) Measure enemy qubit.
+h) Help.
+The analyst can measure enemy qubits.  This forces an enemy qubit
+into the |0> state or |1> state with a probability based on its
+amplitude. Try to measure the enemy qubits as |0> to defwat them.
 """.strip()
     )

--- a/unitary/examples/quantum_rpg/battle_test.py
+++ b/unitary/examples/quantum_rpg/battle_test.py
@@ -130,6 +130,6 @@ m) Measure enemy qubit.
 h) Help.
 The analyst can measure enemy qubits.  This forces an enemy qubit
 into the |0> state or |1> state with a probability based on its
-amplitude. Try to measure the enemy qubits as |0> to defwat them.
+amplitude. Try to measure the enemy qubits as |0> to defeat them.
 """.strip()
     )

--- a/unitary/examples/quantum_rpg/classes.py
+++ b/unitary/examples/quantum_rpg/classes.py
@@ -30,7 +30,7 @@ class Engineer(qaracter.Qaracter):
 
     def help(self) -> str:
         return (
-            "The Engineer can 'attack' by applying an X gate to an enemw'y qubit.\n"
+            "The Engineer can 'attack' by applying an X gate to an enemy qubit.\n"
             "This flips a qubit from |0> to |1> and vice versa."
         )
 
@@ -59,7 +59,7 @@ class Analyst(qaracter.Qaracter):
     def help(self) -> str:
         msg = "The analyst can measure enemy qubits.  This forces an enemy qubit\n"
         msg += "into the |0> state or |1> state with a probability based on its\n"
-        msg += "amplitude. Try to measure the enemy qubits as |0> to defwat them.\n"
+        msg += "amplitude. Try to measure the enemy qubits as |0> to defeat them.\n"
         if self.level >= 3:
             msg += "At level 3 and above, the analyst can sample enemy qubits.\n"
             msg += "This allows you to test the value of a qubit by choosing\n"

--- a/unitary/examples/quantum_rpg/classes.py
+++ b/unitary/examples/quantum_rpg/classes.py
@@ -24,7 +24,18 @@ class Engineer(qaracter.Qaracter):
     Engineeers can do an X gate at level 1 and a H gate at level 3.
     """
 
+    def action_descriptions(self) -> Dict[str, str]:
+        """Descriptions for each player action."""
+        return {"x": "Attack with X gate"}
+
+    def help(self) -> str:
+        return (
+            "The Engineer can 'attack' by applying an X gate to an enemw'y qubit.\n"
+            "This flips a qubit from |0> to |1> and vice versa."
+        )
+
     def actions(self) -> Dict[str, Callable]:
+        """Callables for each player action."""
         actions = {
             "x": lambda monster, qubit: monster.add_quantum_effect(alpha.Flip(), qubit)
         }
@@ -41,10 +52,32 @@ class Analyst(qaracter.Qaracter):
     Analysts can sample ('s') or measure ('m').
     """
 
+    def action_descriptions(self) -> Dict[str, str]:
+        """Descriptions for each player action."""
+        return {"s": "Sample enemy qubit", "m": "Measure enemy qubit"}
+
+    def help(self) -> str:
+        msg = "The analyst can measure enemy qubits.  This forces an enemy qubit\n"
+        msg += "into the |0> state or |1> state with a probability based on its\n"
+        msg += "amplitude. Try to measure the enemy qubits as |0> to defwat them.\n"
+        if self.level >= 3:
+            msg += "At level 3 and above, the analyst can sample enemy qubits.\n"
+            msg += "This allows you to test the value of a qubit by choosing\n"
+            msg += "(or sampling) from a qubit's probability distribution\n"
+            msg += "without modifying the state of the qubit.\n"
+        return msg
+
     def actions(self) -> Dict[str, Callable]:
-        return {
-            "s": lambda monster, qubit: f"Sample result {monster.sample(monster.quantum_object_name(qubit), False)}",
+        """Callables for each player action."""
+        action_dict = {
             "m": lambda monster, qubit: monster.sample(
                 monster.quantum_object_name(qubit), True
             ),
         }
+        if self.level >= 3:
+            action_dict[
+                "s"
+            ] = (
+                lambda monster, qubit: f"Sample result {monster.sample(monster.quantum_object_name(qubit), False)}"
+            )
+        return action_dict

--- a/unitary/examples/quantum_rpg/classes_test.py
+++ b/unitary/examples/quantum_rpg/classes_test.py
@@ -49,6 +49,8 @@ def test_engineer_effects():
 
 def test_analyst_effects():
     qar = classes.Analyst(name="a")
+    qar.add_hp()
+    qar.add_hp()
     test_monster = qaracter.Qaracter("t")
 
     # Test sample
@@ -70,7 +72,7 @@ def test_analyst_effects():
 def test_analyst():
     qar = classes.Analyst(name="a")
     assert not qar.is_npc()
-    assert set(qar.actions().keys()) == {"s", "m"}
+    assert set(qar.actions().keys()) == {"m"}
     qar.add_hp()
     qar.add_hp()
     assert set(qar.actions().keys()) == {"s", "m"}

--- a/unitary/examples/quantum_rpg/encounter_test.py
+++ b/unitary/examples/quantum_rpg/encounter_test.py
@@ -38,7 +38,7 @@ def test_encounter():
     c = classes.Analyst("Aaronson")
     o = npcs.Observer("watcher")
     state = game_state.GameState(
-        party=[c], user_input=["s", "1", "1"], file=io.StringIO()
+        party=[c], user_input=["m", "1", "1"], file=io.StringIO()
     )
     e = encounter.Encounter([o])
 
@@ -53,10 +53,9 @@ Aaronson Analyst   watcher Observer
 1QP (0|1> 0|0> 1?)   1QP (0|1> 0|0> 1?)
 -----------------------------------------------
 Aaronson turn:
-s
-m
-Sample result HealthPoint.HURT
-Observer watcher measures Aaronson_1 as HURT.
+m) Measure enemy qubit.
+h) Help.
+watcher is DOWN!
 """.strip()
     )
 

--- a/unitary/examples/quantum_rpg/main_loop_test.py
+++ b/unitary/examples/quantum_rpg/main_loop_test.py
@@ -164,7 +164,7 @@ Exits: east.
 def test_battle() -> None:
     c = classes.Analyst("Mensing")
     state = game_state.GameState(
-        party=[c], user_input=["e", "south", "s", "1", "1", "quit"], file=io.StringIO()
+        party=[c], user_input=["e", "south", "m", "1", "1", "quit"], file=io.StringIO()
     )
     loop = main_loop.MainLoop(state=state, world=world.World(EXAMPLE_WORLD))
     loop.loop()
@@ -199,10 +199,8 @@ Mensing Analyst   watcher Observer
 1QP (0|1> 0|0> 1?)   1QP (0|1> 0|0> 1?)
 -----------------------------------------------
 Mensing turn:
-s
-m
-Sample result HealthPoint.HURT
-Observer watcher measures Mensing_1 as HURT.
+m) Measure enemy qubit.
+h) Help.
 Cryostats
 
 Giant aluminum cylinders hang suspended by large frames.


### PR DESCRIPTION
Now, the qaracter actions are explained, such as:
`s) Sample enemy qubit.`

There is also a help option within the battle.