### PR TITLE
[Quantum RPG] Improve text formatting

### DIFF
--- a/unitary/examples/quantum_rpg/battle.py
+++ b/unitary/examples/quantum_rpg/battle.py
@@ -21,6 +21,12 @@ import unitary.examples.quantum_rpg.input_helpers as input_helpers
 from unitary.examples.quantum_rpg.qaracter import Qaracter
 from unitary.examples.quantum_rpg.xp_utils import EncounterXp
 
+# Size of the player side of battle status,
+# for text alingment
+_PLAYER_LEN = 40
+
+_BATTLE_SEPARATOR = "-" * (_PLAYER_LEN + 20)
+
 
 class BattleResult(enum.Enum):
     UNFINISHED = 0
@@ -67,16 +73,16 @@ class Battle:
 
         Output will be written to the `file` attribute.
         """
-        print("-----------------------------------------------", file=self.file)
+        print(_BATTLE_SEPARATOR, file=self.file)
         for i in range(max(len(self.player_side), len(self.enemy_side))):
             status = ""
             if i < len(self.player_side):
-                status += (
+                player_status = (
                     f"{self.player_side[i].name} {type(self.player_side[i]).__name__}"
                 )
+                status += f"{player_status: <{_PLAYER_LEN}}"
             else:
-                status += "\t\t"
-            status += "\t\t\t"
+                status += " " * (_PLAYER_LEN)
             if i < len(self.enemy_side):
                 status += (
                     f"{self.enemy_side[i].name} {type(self.enemy_side[i]).__name__}"
@@ -85,14 +91,13 @@ class Battle:
             status += "\n"
 
             if i < len(self.player_side):
-                status += self.player_side[i].status_line()
+                status += f"{self.player_side[i].status_line(): <{_PLAYER_LEN}}"
             else:
-                status += "\t\t"
-            status += "\t\t\t"
+                status += " " * (_PLAYER_LEN)
             if i < len(self.enemy_side):
                 status += self.enemy_side[i].status_line()
             print(status, file=self.file)
-        print("-----------------------------------------------", file=self.file)
+        print(_BATTLE_SEPARATOR, file=self.file)
 
     def take_player_turn(self):
         """Take a player's turn and record results in the battle.

--- a/unitary/examples/quantum_rpg/battle_test.py
+++ b/unitary/examples/quantum_rpg/battle_test.py
@@ -31,10 +31,10 @@ def test_battle():
     assert (
         state.file.getvalue().replace("\t", " ").strip()
         == r"""
------------------------------------------------
-Aaronson Analyst   watcher Observer
-1QP (0|1> 0|0> 1?)   1QP (0|1> 0|0> 1?)
------------------------------------------------
+------------------------------------------------------------
+Aaronson Analyst                        watcher Observer
+1QP (0|1> 0|0> 1?)                      1QP (0|1> 0|0> 1?)
+------------------------------------------------------------
 Aaronson turn:
 m) Measure enemy qubit.
 h) Help.
@@ -54,10 +54,10 @@ def test_bad_monster():
     assert (
         state.file.getvalue().replace("\t", " ").strip()
         == r"""
------------------------------------------------
-Aaronson Analyst   watcher Observer
-1QP (0|1> 0|0> 1?)   1QP (0|1> 0|0> 1?)
------------------------------------------------
+------------------------------------------------------------
+Aaronson Analyst                        watcher Observer
+1QP (0|1> 0|0> 1?)                      1QP (0|1> 0|0> 1?)
+------------------------------------------------------------
 Aaronson turn:
 m) Measure enemy qubit.
 h) Help.
@@ -77,10 +77,10 @@ def test_bad_qubit():
     assert (
         state.file.getvalue().replace("\t", " ").strip()
         == r"""
------------------------------------------------
-Aaronson Analyst   watcher Observer
-1QP (0|1> 0|0> 1?)   1QP (0|1> 0|0> 1?)
------------------------------------------------
+------------------------------------------------------------
+Aaronson Analyst                        watcher Observer
+1QP (0|1> 0|0> 1?)                      1QP (0|1> 0|0> 1?)
+------------------------------------------------------------
 Aaronson turn:
 m) Measure enemy qubit.
 h) Help.
@@ -99,10 +99,10 @@ def test_battle_loop():
     assert (
         state.file.getvalue().replace("\t", " ").strip()
         == r"""
------------------------------------------------
-Aaronson Analyst   watcher Observer
-1QP (0|1> 0|0> 1?)   1QP (0|1> 0|0> 1?)
------------------------------------------------
+------------------------------------------------------------
+Aaronson Analyst                        watcher Observer
+1QP (0|1> 0|0> 1?)                      1QP (0|1> 0|0> 1?)
+------------------------------------------------------------
 Aaronson turn:
 m) Measure enemy qubit.
 h) Help.
@@ -121,10 +121,10 @@ def test_battle_help():
     assert (
         state.file.getvalue().replace("\t", " ").strip()
         == r"""
------------------------------------------------
-Aaronson Analyst   watcher Observer
-1QP (0|1> 0|0> 1?)   1QP (0|1> 0|0> 1?)
------------------------------------------------
+------------------------------------------------------------
+Aaronson Analyst                        watcher Observer
+1QP (0|1> 0|0> 1?)                      1QP (0|1> 0|0> 1?)
+------------------------------------------------------------
 Aaronson turn:
 m) Measure enemy qubit.
 h) Help.

--- a/unitary/examples/quantum_rpg/encounter_test.py
+++ b/unitary/examples/quantum_rpg/encounter_test.py
@@ -48,10 +48,10 @@ def test_encounter():
     assert (
         state.file.getvalue().replace("\t", " ").strip()
         == r"""
------------------------------------------------
-Aaronson Analyst   watcher Observer
-1QP (0|1> 0|0> 1?)   1QP (0|1> 0|0> 1?)
------------------------------------------------
+------------------------------------------------------------
+Aaronson Analyst                        watcher Observer
+1QP (0|1> 0|0> 1?)                      1QP (0|1> 0|0> 1?)
+------------------------------------------------------------
 Aaronson turn:
 m) Measure enemy qubit.
 h) Help.

--- a/unitary/examples/quantum_rpg/main_loop.py
+++ b/unitary/examples/quantum_rpg/main_loop.py
@@ -95,9 +95,16 @@ class MainLoop:
                             if result == battle.BattleResult.PLAYERS_WON:
                                 awarded_xp = current_battle.xp
                                 xp_utils.award_xp(self.game_state, awarded_xp)
-                            if result == battle.BattleResult.PLAYERS_DOWN:
+                            elif result == battle.BattleResult.PLAYERS_DOWN:
                                 raise exceptions.UntimelyDeathException(
                                     "You have been defeated!"
+                                )
+                            elif result == battle.BattleResult.PLAYERS_ESCAPED:
+                                print("You have escaped the battle!", file=self.file)
+                            elif result == battle.BattleResult.ENEMIES_ESCAPED:
+                                print(
+                                    "The enemies have run away and escaped!",
+                                    file=self.file,
                                 )
                             break
                     if result is not None:

--- a/unitary/examples/quantum_rpg/main_loop_test.py
+++ b/unitary/examples/quantum_rpg/main_loop_test.py
@@ -15,6 +15,7 @@ from typing import cast
 
 import copy
 import io
+import unitary.alpha as alpha
 import unitary.examples.quantum_rpg.ascii_art as ascii_art
 import unitary.examples.quantum_rpg.classes as classes
 import unitary.examples.quantum_rpg.encounter as encounter
@@ -261,10 +262,10 @@ Rhythmic whirring of a pulse tube can be heard overhead.
 Exits: north.
 
 A weird security guard approaches!
------------------------------------------------
-Mensing Analyst   watcher Observer
-1QP (0|1> 0|0> 1?)   1QP (0|1> 0|0> 1?)
------------------------------------------------
+------------------------------------------------------------
+Mensing Analyst                         watcher Observer
+1QP (0|1> 0|0> 1?)                      1QP (0|1> 0|0> 1?)
+------------------------------------------------------------
 Mensing turn:
 m) Measure enemy qubit.
 h) Help.
@@ -315,10 +316,10 @@ Rhythmic whirring of a pulse tube can be heard overhead.
 Exits: north.
 
 A weird security guard approaches!
------------------------------------------------
-Mensing Engineer   watcher Observer
-1QP (0|1> 0|0> 1?)   1QP (0|1> 0|0> 1?)
------------------------------------------------
+------------------------------------------------------------
+Mensing Engineer                        watcher Observer
+1QP (0|1> 0|0> 1?)                      1QP (0|1> 0|0> 1?)
+------------------------------------------------------------
 Mensing turn:
 x) Attack with X gate.
 h) Help.
@@ -329,6 +330,62 @@ You have been defeated!
         + """
 You have been measured and were found wanting.
 Better luck next repetition."""
+    )
+
+
+def test_escaped_battle():
+    c = classes.Engineer("Mensing")
+    c.add_quantum_effect(alpha.Flip(), 1)
+    state = game_state.GameState(
+        party=[c], user_input=["e", "south", "x", "1", "1", "quit"], file=io.StringIO()
+    )
+    assert state.party[0].name == "Mensing"
+    assert len(state.party[0].active_qubits()) == 1
+    loop = main_loop.MainLoop(state=state, world=world.World(example_world()))
+    loop.loop()
+    assert state.party[0].name == "Mensing"
+    assert len(state.party[0].active_qubits()) == 1
+
+    assert (
+        cast(io.StringIO, state.file).getvalue().replace("\t", " ").strip()
+        == r"""Lab Entrance
+
+You stand before the entrance to the premier quantum lab.
+Double doors lead east.
+
+Exits: east.
+
+Disorganized Lab
+
+Tables are here with tons of electronics.
+The lab continues to the south.
+A helpful sign is here.
+
+Exits: south, west.
+
+Cryostats
+
+Giant aluminum cylinders hang suspended by large frames.
+Rhythmic whirring of a pulse tube can be heard overhead.
+
+Exits: north.
+
+A weird security guard approaches!
+------------------------------------------------------------
+Mensing Engineer                        watcher Observer
+1QP (0|1> 0|0> 1?)                      1QP (0|1> 0|0> 1?)
+------------------------------------------------------------
+Mensing turn:
+x) Attack with X gate.
+h) Help.
+Observer watcher measures Mensing_1 as HEALTHY.
+You have escaped the battle!
+Cryostats
+
+Giant aluminum cylinders hang suspended by large frames.
+Rhythmic whirring of a pulse tube can be heard overhead.
+
+Exits: north."""
     )
 
 


### PR DESCRIPTION
- Change status lines to fixed format to improve the alignment.  Otherwise, short or long names can throw off the alignment of the status line.
- Also adds a text message explaining what happened if the players or enemies escape the battle.