### PR TITLE
[Quantum RPG] Quantopedia

### DIFF
--- a/unitary/examples/quantum_rpg/battle.py
+++ b/unitary/examples/quantum_rpg/battle.py
@@ -14,7 +14,7 @@
 import enum
 import io
 import sys
-from typing import List, Optional
+from typing import List, Optional, Set
 
 import unitary.examples.quantum_rpg.game_state as game_state
 import unitary.examples.quantum_rpg.input_helpers as input_helpers
@@ -62,6 +62,7 @@ class Battle:
         self.player_side = [qar.copy() for qar in state.party]
         self.enemy_side = enemy_side
         self.file = state.file
+        self.game_state = state
         self.xp = xp
         self.get_user_input = state.get_user_input
 
@@ -77,7 +78,9 @@ class Battle:
         for i in range(max(len(self.player_side), len(self.enemy_side))):
             status = ""
             if i < len(self.player_side):
-                player_status = f"{self.player_side[i].name} {self.player_side[i].class_name}"
+                player_status = (
+                    f"{self.player_side[i].name} {self.player_side[i].class_name}"
+                )
                 status += f"{player_status: <{_PLAYER_LEN}}"
             else:
                 status += " " * (_PLAYER_LEN)
@@ -119,12 +122,28 @@ class Battle:
             descriptions = current_player.action_descriptions()
             for key in sorted(actions):
                 print(f"{key}) {descriptions[key]}.", file=self.file)
+            print("q) Read Quantopedia.", file=self.file)
             print("h) Help.", file=self.file)
-            action = "h"
-            while action == "h":
+            while True:
                 action = self.get_user_input("Choose your action: ")
                 if action == "h":
                     print(current_player.help(), file=self.file)
+                elif action == "q":
+                    seen_types: Set[str] = set()
+                    for enemy in self.enemy_side:
+                        enemy_type = type(enemy).__name__
+                        enemy_index = enemy.quantopedia_index()
+                        if enemy_type not in seen_types:
+                            if self.game_state.has_quantopedia(enemy_index):
+                                print(enemy.quantopedia_entry(), file=self.file)
+                            else:
+                                print(
+                                    f"You do not have information on {enemy_type} yet.",
+                                    file=self.file,
+                                )
+                            seen_types.add(enemy_type)
+                else:
+                    break
             if action in current_player.actions():
                 monster = (
                     input_helpers.get_user_input_number(

--- a/unitary/examples/quantum_rpg/battle_test.py
+++ b/unitary/examples/quantum_rpg/battle_test.py
@@ -37,6 +37,7 @@ Aaronson Analyst                        watcher Observer
 ------------------------------------------------------------
 Aaronson turn:
 m) Measure enemy qubit.
+q) Read Quantopedia.
 h) Help.
 watcher is DOWN!
 """.strip()
@@ -60,6 +61,7 @@ Aaronson Analyst                        watcher Observer
 ------------------------------------------------------------
 Aaronson turn:
 m) Measure enemy qubit.
+q) Read Quantopedia.
 h) Help.
 Invalid number selected.
 """.strip()
@@ -83,6 +85,7 @@ Aaronson Analyst                        watcher Observer
 ------------------------------------------------------------
 Aaronson turn:
 m) Measure enemy qubit.
+q) Read Quantopedia.
 h) Help.
 """.strip()
     )
@@ -105,6 +108,7 @@ Aaronson Analyst                        watcher Observer
 ------------------------------------------------------------
 Aaronson turn:
 m) Measure enemy qubit.
+q) Read Quantopedia.
 h) Help.
 """.strip()
     )
@@ -127,9 +131,60 @@ Aaronson Analyst                        watcher Observer
 ------------------------------------------------------------
 Aaronson turn:
 m) Measure enemy qubit.
+q) Read Quantopedia.
 h) Help.
 The analyst can measure enemy qubits.  This forces an enemy qubit
 into the |0> state or |1> state with a probability based on its
 amplitude. Try to measure the enemy qubits as |0> to defeat them.
+""".strip()
+    )
+
+
+def test_read_quantopedia_not_known():
+    c = classes.Analyst("Aaronson")
+    e = npcs.Observer("watcher")
+    state = game_state.GameState(
+        party=[c], user_input=["q", "m", "1", "1"], file=io.StringIO()
+    )
+    b = battle.Battle(state, [e])
+    assert b.loop() == battle.BattleResult.PLAYERS_WON
+    assert (
+        state.file.getvalue().replace("\t", " ").strip()
+        == r"""
+------------------------------------------------------------
+Aaronson Analyst                        watcher Observer
+1QP (0|1> 0|0> 1?)                      1QP (0|1> 0|0> 1?)
+------------------------------------------------------------
+Aaronson turn:
+m) Measure enemy qubit.
+q) Read Quantopedia.
+h) Help.
+You do not have information on Observer yet.
+""".strip()
+    )
+
+
+def test_read_quantopedia():
+    c = classes.Analyst("Aaronson")
+    e = npcs.Observer("watcher")
+    state = game_state.GameState(
+        party=[c], user_input=["q", "m", "1", "1"], file=io.StringIO()
+    )
+    state.set_quantopedia(1)
+    b = battle.Battle(state, [e])
+    assert b.loop() == battle.BattleResult.PLAYERS_WON
+    assert (
+        state.file.getvalue().replace("\t", " ").strip()
+        == r"""
+------------------------------------------------------------
+Aaronson Analyst                        watcher Observer
+1QP (0|1> 0|0> 1?)                      1QP (0|1> 0|0> 1?)
+------------------------------------------------------------
+Aaronson turn:
+m) Measure enemy qubit.
+q) Read Quantopedia.
+h) Help.
+Observers are known to frequent quantum events.
+They will measure qubits in order to find out their values.
 """.strip()
     )

--- a/unitary/examples/quantum_rpg/battle_test.py
+++ b/unitary/examples/quantum_rpg/battle_test.py
@@ -151,7 +151,7 @@ def test_read_quantopedia_not_known():
         state.file.getvalue().replace("\t", " ").strip()
         == r"""
 ------------------------------------------------------------
-Aaronson Analyst                        watcher Observer
+Aaronson Analyst                        1) watcher Observer
 1QP (0|1> 0|0> 1?)                      1QP (0|1> 0|0> 1?)
 ------------------------------------------------------------
 Aaronson turn:
@@ -176,7 +176,7 @@ def test_read_quantopedia():
         state.file.getvalue().replace("\t", " ").strip()
         == r"""
 ------------------------------------------------------------
-Aaronson Analyst                        watcher Observer
+Aaronson Analyst                        1) watcher Observer
 1QP (0|1> 0|0> 1?)                      1QP (0|1> 0|0> 1?)
 ------------------------------------------------------------
 Aaronson turn:

--- a/unitary/examples/quantum_rpg/encounter_test.py
+++ b/unitary/examples/quantum_rpg/encounter_test.py
@@ -54,6 +54,7 @@ Aaronson Analyst                        watcher Observer
 ------------------------------------------------------------
 Aaronson turn:
 m) Measure enemy qubit.
+q) Read Quantopedia.
 h) Help.
 watcher is DOWN!
 """.strip()

--- a/unitary/examples/quantum_rpg/final_state_preparation/oxtail_university.py
+++ b/unitary/examples/quantum_rpg/final_state_preparation/oxtail_university.py
@@ -70,7 +70,7 @@ def _engineer_joins(state: GameState, world) -> str:
 
 def _quantopedia(state: GameState, world) -> str:
     print(
-        "These books contain information about all the types of quantum foam",
+        "These books contain information about all the types of quantum foam.",
         file=state.file,
     )
     print("You can now type 'q' during a battle to learn about it.", file=state.file)

--- a/unitary/examples/quantum_rpg/final_state_preparation/oxtail_university.py
+++ b/unitary/examples/quantum_rpg/final_state_preparation/oxtail_university.py
@@ -22,7 +22,13 @@ from unitary.examples.quantum_rpg.final_state_preparation.monsters import (
     blue_foam,
 )
 from unitary.examples.quantum_rpg.item import EXAMINE, TALK, Item
-from unitary.examples.quantum_rpg.npcs import BlueFoam, GreenFoam, Observer
+from unitary.examples.quantum_rpg.npcs import (
+    BlueFoam,
+    GreenFoam,
+    RedFoam,
+    PurpleFoam,
+    Observer,
+)
 from unitary.examples.quantum_rpg.xp_utils import EncounterXp
 from unitary.examples.quantum_rpg.world import Direction, Location
 
@@ -30,13 +36,28 @@ from unitary.examples.quantum_rpg.world import Direction, Location
 def _engineer_joins(state: GameState, world) -> str:
     if len(state.party) > 1:
         return f"The engineer reminisces about his former experiment."
-    print("The engineer looks at the apparatus that dominates the room.")
-    print("'NMR has been a promising technology for quantum computing,'")
-    print("the engineer says.  'And we have learned a lot.  But, ultimately,")
-    print("I can already see that this technology is not scalable and will")
-    print("not solve the problems that plague us today.  I will leave this")
-    print("for the scientists working in other disciplines and join you")
-    print("on the journey towards quantum error correction!")
+    print(
+        "The engineer looks at the apparatus that dominates the room.", file=state.file
+    )
+    print(
+        "'NMR has been a promising technology for quantum computing,'", file=state.file
+    )
+    print(
+        "the engineer says.  'And we have learned a lot.  But, ultimately,",
+        file=state.file,
+    )
+    print(
+        "I can already see that this technology is not scalable and will",
+        file=state.file,
+    )
+    print(
+        "not solve the problems that plague us today.  I will leave this",
+        file=state.file,
+    )
+    print(
+        "for the scientists working in other disciplines and join you", file=state.file
+    )
+    print("on the journey towards quantum error correction!", file=state.file)
 
     name = get_user_input_qaracter_name(
         state.get_user_input, "the engineer", file=state.file
@@ -45,6 +66,15 @@ def _engineer_joins(state: GameState, world) -> str:
     state.party.append(qar)
 
     return f"{name} has joined the group!"
+
+
+def _quantopedia(state: GameState, world) -> str:
+    print(
+        "These books contain information about all the types of quantum foam",
+        file=state.file,
+    )
+    print("You can now type 'q' during a battle to learn about it.", file=state.file)
+    state.set_quantopedia(1)
 
 
 ENGINEER = Item(
@@ -56,6 +86,24 @@ ENGINEER = Item(
         )
     ],
     description="The engineer stands here wondering how to build a better quantum computer.",
+)
+
+QUANTOPEDIA = Item(
+    keyword_actions=[
+        (
+            EXAMINE,
+            [
+                "bookshelves",
+                "bookshelf",
+                "books",
+                "book",
+                "shelf",
+                "quantopedia",
+                "library",
+            ],
+            _quantopedia,
+        )
+    ],
 )
 
 OXTAIL_RUINS = Item(
@@ -205,6 +253,40 @@ SPECTROMETER = Item(
 )
 
 
+BIOLOGIST1 = Item(
+    keyword_actions=[
+        (
+            TALK,
+            ["biologist", "professor", "prof", "scientist"],
+            "'The foam' the professors yells in a panic.  'It has escaped!'",
+        )
+    ]
+)
+
+BIOLOGIST2 = Item(
+    keyword_actions=[
+        (
+            TALK,
+            ["biologist", "professor", "prof", "scientist"],
+            "'What have we done?' one of the biologists laments and puts his head in his hands.",
+        )
+    ]
+)
+
+
+BIO_STUDENT = Item(
+    keyword_actions=[
+        (
+            TALK,
+            ["student", "students"],
+            (
+                "'I am looking for information on how to stop the quantum foam.' the student\n"
+                "explains.  'These bookshelves contain a multitude of information about quantum foam."
+            ),
+        )
+    ]
+)
+
 OXTAIL_UNIVERSITY = [
     Location(
         label="oxtail1",
@@ -337,10 +419,10 @@ OXTAIL_UNIVERSITY = [
         label="quad8",
         title="South end",
         description=(
-            "Here on the south end of campus is the mathematics\n"
+            "Here on the south end of campus is the biology\n"
             "department.  Most of the windows and doors have been\n"
             "boarded up or blocked.  A hastily drawn sign on the\n"
-            "entrance proclaims: 'QUIET PLEASE! THEOREM CREATION IN PROGRESS.'"
+            "entrance proclaims: 'BIOHAZARD!  DO NOT ENTER.'"
         ),
         items=[STUDENT[2]],
         encounters=[blue_foam(2, 0.2)],
@@ -348,6 +430,7 @@ OXTAIL_UNIVERSITY = [
             Direction.WEST: "quad7",
             Direction.NORTH: "quad5",
             Direction.EAST: "quad9",
+            Direction.SOUTH: "bio1",
         },
     ),
     Location(
@@ -459,5 +542,64 @@ OXTAIL_UNIVERSITY = [
         ),
         items=[SPECTROMETER, ENGINEER],
         exits={Direction.DOWN: "nmr_lab2"},
+    ),
+    Location(
+        label="bio1",
+        title="Inside the Biology Laboratory",
+        description=(
+            "The inside of the biology building is a bustle of activity.\n"
+            "Grad students are furiously boarding up classroom doors and\n"
+            "windows, while several biology professors yell orders.\n"
+            "Most of the entrances are now blocked, though one door to the\n"
+            "south has not yet been barred.  To the east is a small library."
+        ),
+        items=[BIOLOGIST1],
+        exits={
+            Direction.NORTH: "quad8",
+            Direction.SOUTH: "bio3",
+            Direction.EAST: "bio2",
+        },
+    ),
+    Location(
+        label="bio2",
+        title="The Biology Library",
+        description=(
+            "A smalll library filled with bookshelves has become a refuge\n"
+            "for exhausted biologists and students.  Several are collapsed\n"
+            "on desks and tables all around the room.  A few students are\n"
+            "furiously paging through thick books in search of solutions."
+        ),
+        items=[BIOLOGIST2, BIO_STUDENT, QUANTOPEDIA],
+        exits={Direction.WEST: "bio1"},
+    ),
+    Location(
+        label="bio3",
+        title="Wrecked Laboratory",
+        description=(
+            "Rows of laboratory tables are covered with broken glass, oozing\n"
+            "foam, and corroded instruments.  A row of tall glass beakers in\n"
+            "the back of the labs have cracked and broken.  Pulsing quantum\n"
+            "foam covers neearly all the surfaces of the lab, and broken pieces\n"
+            "of white and black static noise dot the walls."
+        ),
+        items=[],
+        encounters=[
+            Encounter(
+                [
+                    BlueFoam("Blue Foamy"),
+                    BlueFoam("Blue Slimy"),
+                    GreenFoam("Green Gooey"),
+                    GreenFoam("Green Ooze"),
+                    RedFoam("Red Goo"),
+                    RedFoam("Red Glop"),
+                    PurpleFoam("Pulsing Purple Slime"),
+                    PurpleFoam("Pulsating Purple Foam"),
+                ],
+                probability=1.0,
+                description="Quantum foam engulfs you from all sides!",
+                xp=EncounterXp([[alpha.Flip()]]),
+            )
+        ],
+        exits={Direction.NORTH: "bio1"},
     ),
 ]

--- a/unitary/examples/quantum_rpg/game_state.py
+++ b/unitary/examples/quantum_rpg/game_state.py
@@ -43,17 +43,29 @@ class GameState:
         self.get_user_input = input_helpers.get_user_input_function(user_input)
         self.file = file
 
-    def set_quantopedia(self, num):
+    def set_quantopedia(self, num: int) -> None:
+        """Convenience method for setting a quantopedia bit.
+
+        The quantopedia is repesented by a bitstring in the
+        state_dict.  During a battle, if the bit for the enemy
+        NPC is set, then the entry for that type of NPC is displayed.
+        """
         if _QUANTOPEDIA_KEY not in self.state_dict:
             self.state_dict[_QUANTOPEDIA_KEY] = "0"
         quantopedia_num = int(self.state_dict[_QUANTOPEDIA_KEY]) | num
         self.state_dict[_QUANTOPEDIA_KEY] = str(quantopedia_num)
 
-    def has_quantopedia(self, num):
+    def has_quantopedia(self, num: int) -> bool:
+        """Convenience method for getting  a quantopedia bit.
+
+        The quantopedia is repesented by a bitstring in the
+        state_dict.  During a battle, if the bit for the enemy
+        NPC is set, then the entry for that type of NPC is displayed.
+        """
         if _QUANTOPEDIA_KEY not in self.state_dict:
             return False
         quantopedia_num = int(self.state_dict[_QUANTOPEDIA_KEY])
-        return (quantopedia_num // num) % 2 == 1
+        return quantopedia_num & num != 0
 
     def with_save_file(self, save_file) -> "GameState":
         """Modifies GameState object in place to load info from save file.

--- a/unitary/examples/quantum_rpg/game_state.py
+++ b/unitary/examples/quantum_rpg/game_state.py
@@ -23,6 +23,7 @@ import unitary.examples.quantum_rpg.qaracter as qaracter
 
 _SAVE_DELIMITER = ";"
 _DICT_DELIMITER = ":"
+_QUANTOPEDIA_KEY = "qp"
 
 
 class GameState:
@@ -41,6 +42,18 @@ class GameState:
         self.user_input = user_input
         self.get_user_input = input_helpers.get_user_input_function(user_input)
         self.file = file
+
+    def set_quantopedia(self, num):
+        if _QUANTOPEDIA_KEY not in self.state_dict:
+            self.state_dict[_QUANTOPEDIA_KEY] = "0"
+        quantopedia_num = int(self.state_dict[_QUANTOPEDIA_KEY]) | num
+        self.state_dict[_QUANTOPEDIA_KEY] = str(quantopedia_num)
+
+    def has_quantopedia(self, num):
+        if _QUANTOPEDIA_KEY not in self.state_dict:
+            return False
+        quantopedia_num = int(self.state_dict[_QUANTOPEDIA_KEY])
+        return (quantopedia_num // num) % 2 == 1
 
     def with_save_file(self, save_file) -> "GameState":
         """Modifies GameState object in place to load info from save file.

--- a/unitary/examples/quantum_rpg/game_state_test.py
+++ b/unitary/examples/quantum_rpg/game_state_test.py
@@ -51,3 +51,17 @@ def test_serialization() -> None:
     assert deserialized_qar2.name == qar2.name
     assert deserialized_qar2.level == qar2.level
     assert deserialized_qar2.circuit == qar2.circuit
+
+
+def test_quantopedia():
+    state = game_state.GameState([])
+    assert not state.has_quantopedia(8)
+    assert not state.has_quantopedia(4)
+    assert not state.has_quantopedia(2)
+    assert not state.has_quantopedia(1)
+    state.set_quantopedia(4)
+    state.set_quantopedia(1)
+    assert not state.has_quantopedia(8)
+    assert state.has_quantopedia(4)
+    assert not state.has_quantopedia(2)
+    assert state.has_quantopedia(1)

--- a/unitary/examples/quantum_rpg/main_loop_test.py
+++ b/unitary/examples/quantum_rpg/main_loop_test.py
@@ -308,6 +308,7 @@ Mensing Analyst                         watcher Observer
 ------------------------------------------------------------
 Mensing turn:
 m) Measure enemy qubit.
+q) Read Quantopedia.
 h) Help.
 Cryostats
 
@@ -362,6 +363,7 @@ Mensing Engineer                        watcher Observer
 ------------------------------------------------------------
 Mensing turn:
 x) Attack with X gate.
+q) Read Quantopedia.
 h) Help.
 Observer watcher measures Mensing_1 as HURT.
 You have been defeated!
@@ -417,6 +419,7 @@ Mensing Engineer                        watcher Observer
 ------------------------------------------------------------
 Mensing turn:
 x) Attack with X gate.
+q) Read Quantopedia.
 h) Help.
 Observer watcher measures Mensing_1 as HEALTHY.
 You have escaped the battle!

--- a/unitary/examples/quantum_rpg/npcs.py
+++ b/unitary/examples/quantum_rpg/npcs.py
@@ -67,6 +67,14 @@ class Npc(qaracter.Qaracter):
         action_choice = random.random()
         return self.act_on_enemy_qubit(enemy_qubit, action_choice, **kwargs)
 
+    def quantopedia_index(self) -> int:
+        """Bit to use for quantopedia.  Should be power of two."""
+        return 1
+
+    def quantopedia_entry(self) -> str:
+        """Explanatory text to the players about the NPC."""
+        return "Nothing known about this NPC."
+
 
 #####################
 #
@@ -80,6 +88,12 @@ class Observer(Npc):
 
     def act_on_enemy_qubit(self, enemy_qubit, action_choice, **kwargs) -> str:
         return _sample_qubit(self.display_name, enemy_qubit)
+
+    def quantopedia_entry(self) -> str:
+        return (
+            "Observers are known to frequent quantum events.\n"
+            "They will measure qubits in order to find out their values."
+        )
 
 
 class BlueFoam(Npc):
@@ -96,6 +110,13 @@ class BlueFoam(Npc):
             return f"{self.display_name} slimes {enemy_qubit.name} for {slime:0.3f}."
         else:
             return _sample_qubit(self.display_name, enemy_qubit)
+
+    def quantopedia_entry(self) -> str:
+        return (
+            "Blue foam are the simplest kind of quantum errors.  Blue foam\n"
+            "are usually found in the |0> state and can be measured.\n"
+            "They will often slime their opponents with small fracts of X gates."
+        )
 
 
 class GreenFoam(Npc):
@@ -114,6 +135,13 @@ class GreenFoam(Npc):
             )
         else:
             return _sample_qubit(self.display_name, enemy_qubit)
+
+    def quantopedia_entry(self) -> str:
+        return (
+            "Green foam are a simple kind of quantum error.  Green foam\n"
+            "are usually found in the |0> state and can be measured immediately.\n"
+            "They will often ooze, which will change their opponent's phase"
+        )
 
 
 class RedFoam(Npc):
@@ -135,6 +163,13 @@ class RedFoam(Npc):
         else:
             return _sample_qubit(self.display_name, enemy_qubit)
 
+    def quantopedia_entry(self) -> str:
+        return (
+            "Red foam are a slightly more dangerous type of quantum error.\n"
+            "They are usually found in the |1> state and must be flipped\n"
+            "before they can be safely measured."
+        )
+
 
 class PurpleFoam(Npc):
     """Introductory NPC that starts in |+> state.
@@ -153,3 +188,11 @@ class PurpleFoam(Npc):
             return f"{self.display_name} covers {enemy_qubit.name} with foam!"
         else:
             return _sample_qubit(self.display_name, enemy_qubit)
+
+    def quantopedia_entry(self) -> str:
+        return (
+            "Purple foam are a combination of red and blue form.\n"
+            "They are found in a |+> state which is a combination of\n"
+            "the |0> state and |1> state.  They can be safely measured\n"
+            "once a Hadamard gate has been applied."
+        )

--- a/unitary/examples/quantum_rpg/npcs.py
+++ b/unitary/examples/quantum_rpg/npcs.py
@@ -20,6 +20,17 @@ import unitary.examples.quantum_rpg.enums as enums
 import unitary.examples.quantum_rpg.qaracter as qaracter
 
 
+# QUANTOPEDIA ENTRIES
+#
+#
+# Entry for quantum foam, found in Oxtail library
+_FOAM_QUANTOPEDIA = 1
+# Entry for cat states, found in Hills huts
+_HILLS_QUANTOPEDIA = 2
+# Reserved for Perimeter institute, to be implemented.
+_PERIMETER_QUANTOPEDIA = 4
+
+
 def _enemy_qubits(party: List[qaracter.Qaracter]) -> List[alpha.QuantumObject]:
     """Determines valid enemy target qubits and returns them with the player."""
     enemy_qubits: List[alpha.QuantumObject] = []
@@ -68,8 +79,16 @@ class Npc(qaracter.Qaracter):
         return self.act_on_enemy_qubit(enemy_qubit, action_choice, **kwargs)
 
     def quantopedia_index(self) -> int:
-        """Bit to use for quantopedia.  Should be power of two."""
-        return 1
+        """Bit to use for quantopedia.  Should be power of two.
+
+        This represents the bit that you need to acquire in order
+        to be able to access the `quantopedia_entry` in the help
+        screen.  This bit is set in the game state and is usually
+        set when finding a library or item that grants the bit.
+
+        By default (set to zero), you cannot learn about the NPC.
+        """
+        return 0
 
     def quantopedia_entry(self) -> str:
         """Explanatory text to the players about the NPC."""
@@ -88,6 +107,9 @@ class Observer(Npc):
 
     def act_on_enemy_qubit(self, enemy_qubit, action_choice, **kwargs) -> str:
         return _sample_qubit(self.display_name, enemy_qubit)
+
+    def quantopedia_index(self) -> int:
+        return _FOAM_QUANTOPEDIA
 
     def quantopedia_entry(self) -> str:
         return (
@@ -110,6 +132,9 @@ class BlueFoam(Npc):
             return f"{self.display_name} slimes {enemy_qubit.name} for {slime:0.3f}."
         else:
             return _sample_qubit(self.display_name, enemy_qubit)
+
+    def quantopedia_index(self) -> int:
+        return _FOAM_QUANTOPEDIA
 
     def quantopedia_entry(self) -> str:
         return (
@@ -135,6 +160,9 @@ class GreenFoam(Npc):
             )
         else:
             return _sample_qubit(self.display_name, enemy_qubit)
+
+    def quantopedia_index(self) -> int:
+        return _FOAM_QUANTOPEDIA
 
     def quantopedia_entry(self) -> str:
         return (
@@ -163,6 +191,9 @@ class RedFoam(Npc):
         else:
             return _sample_qubit(self.display_name, enemy_qubit)
 
+    def quantopedia_index(self) -> int:
+        return _FOAM_QUANTOPEDIA
+
     def quantopedia_entry(self) -> str:
         return (
             "Red foam are a slightly more dangerous type of quantum error.\n"
@@ -188,6 +219,9 @@ class PurpleFoam(Npc):
             return f"{self.display_name} covers {enemy_qubit.name} with foam!"
         else:
             return _sample_qubit(self.display_name, enemy_qubit)
+
+    def quantopedia_index(self) -> int:
+        return _FOAM_QUANTOPEDIA
 
     def quantopedia_entry(self) -> str:
         return (


### PR DESCRIPTION
- Adds an in-game help option for a quantopedia.
- When you find the book or item that has info on the type of enemy you are facing, you can type 'q' and learn about it.