### PR TITLE
[Unitary] Add black to CI

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with:
-          src: "./unitary/quantum_chess"
+          src: "./unitary"


### PR DESCRIPTION
- For some reason, black was only set to check formatting for quantum_chess.  Add it to all of unitary.