### PR TITLE
[Quantum RPG] Add LOOK command

### DIFF
--- a/unitary/examples/quantum_rpg/main_loop.py
+++ b/unitary/examples/quantum_rpg/main_loop.py
@@ -36,6 +36,7 @@ class Command(enum.Enum):
     """
 
     LOAD = "load"
+    LOOK = "look"
     STATUS = "status"
     SAVE = "save"
     HELP = "help"
@@ -163,6 +164,9 @@ class MainLoop:
                     )
                     print(self.game_state.to_save_file(), file=self.file)
                     print("")
+                    print_room_description = False
+                elif input_cmd == Command.LOOK:
+                    print(self.world.current_location, file=self.file)
                     print_room_description = False
                 else:
                     print(

--- a/unitary/examples/quantum_rpg/main_loop_test.py
+++ b/unitary/examples/quantum_rpg/main_loop_test.py
@@ -112,12 +112,19 @@ def test_parse_commands() -> None:
 
 def test_simple_main_loop() -> None:
     c = classes.Analyst("Mensing")
-    state = game_state.GameState(party=[c], user_input=["quit"], file=io.StringIO())
+    state = game_state.GameState(party=[c], user_input=["look", "quit"], file=io.StringIO())
     loop = main_loop.MainLoop(state=state, world=world.World(example_world()))
     loop.loop()
     assert (
         cast(io.StringIO, state.file).getvalue().replace("\t", " ").strip()
         == r"""
+Lab Entrance
+
+You stand before the entrance to the premier quantum lab.
+Double doors lead east.
+
+Exits: east.
+
 Lab Entrance
 
 You stand before the entrance to the premier quantum lab.

--- a/unitary/examples/quantum_rpg/main_loop_test.py
+++ b/unitary/examples/quantum_rpg/main_loop_test.py
@@ -112,7 +112,9 @@ def test_parse_commands() -> None:
 
 def test_simple_main_loop() -> None:
     c = classes.Analyst("Mensing")
-    state = game_state.GameState(party=[c], user_input=["look", "quit"], file=io.StringIO())
+    state = game_state.GameState(
+        party=[c], user_input=["look", "quit"], file=io.StringIO()
+    )
     loop = main_loop.MainLoop(state=state, world=world.World(example_world()))
     loop.loop()
     assert (


### PR DESCRIPTION
- Look command displays the location again. (takes lowest precedence in case there is something to look at in the room.)