### PR TITLE
Fix status display for qubits with no effects

### DIFF
--- a/unitary/examples/quantum_rpg/qaracter.py
+++ b/unitary/examples/quantum_rpg/qaracter.py
@@ -156,6 +156,14 @@ class Qaracter(alpha.QuantumWorld):
         """Returns True if the Qaracter is not down yet and there are HPs left to measure."""
         return not self.is_down() and len(self.health_status) < self.level
 
+    def qar_sheet(self) -> str:
+        """Generates a Unicode-art diagram of the qaracter's circuit."""
+        all_qubits = [
+            self.get_object_by_name(self.quantum_object_name(i)).qubit
+            for i in range(1, self.level + 1)
+        ]
+        return self.circuit.to_text_diagram(qubit_order=all_qubits)
+
     def qar_status(self) -> str:
         """Prints out the qaracter's name/class/level and circuit.
 
@@ -163,7 +171,7 @@ class Qaracter(alpha.QuantumWorld):
         """
         return (
             f"{self.name}: Level {self.level} {self.class_name}"
-            f"\nQaracter sheet:\n{self.circuit}"
+            f"\nQaracter sheet:\n{self.qar_sheet()}"
         )
 
     def status_line(self) -> str:

--- a/unitary/examples/quantum_rpg/xp_utils.py
+++ b/unitary/examples/quantum_rpg/xp_utils.py
@@ -97,7 +97,7 @@ def award_xp(
         )
         qar = eligible_party[qar_choice - 1]
         print("Current qaracter sheet:", file=state.file)
-        print(qar.circuit, file=state.file)
+        print(qar.qar_sheet(), file=state.file)
         qubit_list = list(qar.active_qubits())
         qubit_choices = []
         for qubit_num in range(num_qubits):

--- a/unitary/examples/quantum_rpg/xp_utils_test.py
+++ b/unitary/examples/quantum_rpg/xp_utils_test.py
@@ -55,9 +55,9 @@ def test_award_xp():
 Choose the qaracter to add the Superposition to:
 1) wizard: Level 1 Analyst
 Qaracter sheet:
-
+wizard_1: ───
 Current qaracter sheet:
-
+wizard_1: ───
 Choose qubit 0 for Superposition:
 1) wizard_1
 """
@@ -83,9 +83,13 @@ def test_award_xp_multi_qubit_gate():
 Choose the qaracter to add the Move to:
 1) wizard: Level 2 Analyst
 Qaracter sheet:
+wizard_1: ───
 
+wizard_2: ───
 Current qaracter sheet:
+wizard_1: ───
 
+wizard_2: ───
 Choose qubit 0 for Move:
 1) wizard_1
 2) wizard_2


### PR DESCRIPTION
It is confusing how the status display doesn't show qubits that don't have any effects on them. To fix this, specify a qubit order for the diagram, which allows us to force unused qubits to be included.