### PR TITLE
Allow strings to be passed as subscripts or to peek/pop in QuantumWorld

### DIFF
--- a/unitary/alpha/quantum_world_test.py
+++ b/unitary/alpha/quantum_world_test.py
@@ -51,6 +51,10 @@ def test_get_object_by_name(compile_to_qubits):
     assert board.get_object_by_name("test") == light
     assert board.get_object_by_name("test2") == light2
     assert board.get_object_by_name("test3") == None
+    assert board["test"] == light
+    assert board["test2"] == light2
+    with pytest.raises(KeyError):
+        _ = board["test3"]
 
 
 @pytest.mark.parametrize("compile_to_qubits", [False, True])
@@ -62,10 +66,12 @@ def test_one_qubit(simulator, compile_to_qubits):
     )
     assert board.peek() == [[Light.GREEN]]
     assert board.peek([light], count=2) == [[Light.GREEN], [Light.GREEN]]
+    assert board.peek(["test"], count=2) == [[Light.GREEN], [Light.GREEN]]
     light = alpha.QuantumObject("test", 1)
     board = alpha.QuantumWorld([light], compile_to_qubits=compile_to_qubits)
     assert board.peek() == [[1]]
     assert board.peek([light], count=2) == [[1], [1]]
+    assert board.peek(["test"], count=2) == [[1], [1]]
     assert board.pop() == [1]
 
 
@@ -81,6 +87,8 @@ def test_two_qubits(simulator, compile_to_qubits):
     assert board.peek(convert_to_enum=False) == [[1, 0]]
     assert board.peek([light], count=2) == [[Light.GREEN], [Light.GREEN]]
     assert board.peek([light2], count=2) == [[Light.RED], [Light.RED]]
+    assert board.peek(["green"], count=2) == [[Light.GREEN], [Light.GREEN]]
+    assert board.peek(["red"], count=2) == [[Light.RED], [Light.RED]]
     assert board.peek(count=3) == [
         [Light.GREEN, Light.RED],
         [Light.GREEN, Light.RED],
@@ -173,6 +181,8 @@ def test_pop(simulator, compile_to_qubits):
     assert not all(result[0] == 0 for result in results)
     assert not all(result[0] == 1 for result in results)
     popped = board.pop([light2])[0]
+    popped2 = board.pop(["l2"])[0]
+    assert popped == popped2
     results = board.peek([light2, light3], count=200)
     assert len(results) == 200
     assert all(result[0] == popped for result in results)


### PR DESCRIPTION
Allows strings to be passed to peek() and pop()

Also returns the object when world["name"] is called.