### PR TITLE
implemented quantopedia command

### DIFF
--- a/examples/quantum_rpg/main_loop_test.py
+++ b/examples/quantum_rpg/main_loop_test.py
@@ -105,8 +105,8 @@ ______                         ||              _    _
 
 def test_parse_commands() -> None:
     assert main_loop.Command.parse("x") is None
-    assert main_loop.Command.parse("q") is main_loop.Command.QUIT
-    assert main_loop.Command.parse("Q") is main_loop.Command.QUIT
+    assert main_loop.Command.parse("qui") is main_loop.Command.QUIT
+    assert main_loop.Command.parse("Qui") is main_loop.Command.QUIT
     assert main_loop.Command.parse("Quit") is main_loop.Command.QUIT
     assert main_loop.Command.parse("quit") is main_loop.Command.QUIT
 

--- a/examples/quantum_rpg/npcs.py
+++ b/examples/quantum_rpg/npcs.py
@@ -91,7 +91,8 @@ class Npc(qaracter.Qaracter):
         """
         return 0
 
-    def quantopedia_entry(self) -> str:
+    @classmethod
+    def quantopedia_entry(cls) -> str:
         """Explanatory text to the players about the NPC."""
         return "Nothing known about this NPC."
 
@@ -112,7 +113,8 @@ class Observer(Npc):
     def quantopedia_index(self) -> int:
         return _FOAM_QUANTOPEDIA
 
-    def quantopedia_entry(self) -> str:
+    @classmethod
+    def quantopedia_entry(cls) -> str:
         return (
             "Observers are known to frequent quantum events.\n"
             "They will measure qubits in order to find out their values."
@@ -137,7 +139,8 @@ class BlueFoam(Npc):
     def quantopedia_index(self) -> int:
         return _FOAM_QUANTOPEDIA
 
-    def quantopedia_entry(self) -> str:
+    @classmethod
+    def quantopedia_entry(cls) -> str:
         return (
             "Blue foam are the simplest kind of quantum errors.  Blue foam\n"
             "are usually found in the |0> state and can be measured.\n"
@@ -165,7 +168,8 @@ class GreenFoam(Npc):
     def quantopedia_index(self) -> int:
         return _FOAM_QUANTOPEDIA
 
-    def quantopedia_entry(self) -> str:
+    @classmethod
+    def quantopedia_entry(cls) -> str:
         return (
             "Green foam are a simple kind of quantum error.  Green foam\n"
             "are usually found in the |0> state and can be measured immediately.\n"
@@ -195,7 +199,8 @@ class RedFoam(Npc):
     def quantopedia_index(self) -> int:
         return _FOAM_QUANTOPEDIA
 
-    def quantopedia_entry(self) -> str:
+    @classmethod
+    def quantopedia_entry(cls) -> str:
         return (
             "Red foam are a slightly more dangerous type of quantum error.\n"
             "They are usually found in the |1> state and must be flipped\n"
@@ -224,7 +229,8 @@ class PurpleFoam(Npc):
     def quantopedia_index(self) -> int:
         return _FOAM_QUANTOPEDIA
 
-    def quantopedia_entry(self) -> str:
+    @classmethod
+    def quantopedia_entry(cls) -> str:
         return (
             "Purple foam are a combination of red and blue form.\n"
             "They are found in a |+> state which is a combination of\n"
@@ -268,7 +274,8 @@ class SchrodingerCat(Npc):
     def quantopedia_index(self) -> int:
         return _HILLS_QUANTOPEDIA
 
-    def quantopedia_entry(self) -> str:
+    @classmethod
+    def quantopedia_entry(cls) -> str:
         return (
             "Schrödinger's cat are found in a superposition of zero and one.\n"
             "This cat contains multiple qubits that are entangled so that all\n"


### PR DESCRIPTION
Fixes #177

Output looks like this:

```
>qua

Observer
  Observers are known to frequent quantum events.
  They will measure qubits in order to find out their values.

BlueFoam
  Blue foam are the simplest kind of quantum errors.  Blue foam
  are usually found in the |0> state and can be measured.
  They will often slime their opponents with small fracts of X gates.

GreenFoam
  Green foam are a simple kind of quantum error.  Green foam
  are usually found in the |0> state and can be measured immediately.
  They will often ooze, which will change their opponent's phase

RedFoam
  Red foam are a slightly more dangerous type of quantum error.
  They are usually found in the |1> state and must be flipped
  before they can be safely measured.

PurpleFoam
  Purple foam are a combination of red and blue form.
  They are found in a |+> state which is a combination of
  the |0> state and |1> state.  They can be safely measured
  once a Hadamard gate has been applied.

SchrodingerCat
  Schrödinger's cat are found in a superposition of zero and one.
  This cat contains multiple qubits that are entangled so that all
  qubits are in the same state.  That is, all qubits are in a superposition
  of all ones or all zeros.  These cats have been known to apply
  Hadamard gates with their claws and measure opponents.
```