### PR TITLE
Allow installation to Python 3.10 environment

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -12,8 +12,9 @@ jobs:
           python-version: '3.12'
           architecture: 'x64'
       - name: Install Pylint
+        # TODO: #210 - install the latest pylint below
         run: |
           python -m pip install --upgrade pip
-          pip install pylint
+          pip install 'pylint<3'
       - name: Pylint check
         run: dev_tools/pylint

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     url="http://github.com/quantumlib/unitary",
     author="Quantum AI team and collaborators",
     author_email="quantum-chess-engineering@googlegroups.com",
-    python_requires=">=3.12.0",
+    python_requires=">=3.10.0",
     install_requires=install_requires,
     license="Apache 2",
     description="",


### PR DESCRIPTION
This is needed for internal documentation tool.
All unit tests pass with Python 3.10.

Also restrict the CI check to use pylint-2 as
a temporary workaround for #210.