### PR TITLE
Update copyright checker for pylint-3

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -16,9 +16,4 @@ jobs:
           python -m pip install --upgrade pip
           pip install pylint
       - name: Pylint check
-        # TODO: #210 - convert to hard check when lint is picked up
-        run: |
-          dev_tools/pylint || (
-            echo "pylint check failed.  The error is temporarily ignored."
-            echo "See https://github.com/quantumlib/unitary/issues/210"
-          )
+        run: dev_tools/pylint

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -16,4 +16,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install pylint
       - name: Pylint check
-        run: dev_tools/pylint
+        # TODO: #210 - convert to hard check when lint is picked up
+        run: |
+          dev_tools/pylint || (
+            echo "pylint check failed.  The error is temporarily ignored."
+            echo "See https://github.com/quantumlib/unitary/issues/210"
+          )

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -12,9 +12,8 @@ jobs:
           python-version: '3.12'
           architecture: 'x64'
       - name: Install Pylint
-        # TODO: #210 - install the latest pylint below
         run: |
           python -m pip install --upgrade pip
-          pip install 'pylint<3'
+          pip install pylint
       - name: Pylint check
         run: dev_tools/pylint

--- a/dev_tools/.pylintrc
+++ b/dev_tools/.pylintrc
@@ -7,53 +7,53 @@ output-format=colorized
 score=no
 reports=no
 enable=
-    anomalous-backslash-in-string,
+    # anomalous-backslash-in-string,    # TODO: #210 - enable and fix
     assert-on-tuple,
     bad-indentation,
     bad-option-value,
     bad-reversed-sequence,
     bad-super-call,
     consider-merging-isinstance,
-    consider-using-f-string,
+    # consider-using-f-string,  # TODO: #210 - enable and fix
     continue-in-finally,
-    dangerous-default-value,
+    # dangerous-default-value,  # TODO: #210 - enable and fix
     docstyle,
     duplicate-argument-name,
-    expression-not-assigned,
+    # expression-not-assigned,  # TODO: #210 - enable and fix
     f-string-without-interpolation,
-    function-redefined,
+    # function-redefined,       # TODO: #210 - enable and fix
     inconsistent-mro,
     init-is-generator,
-    line-too-long,
+    # line-too-long,            # TODO: #210 - enable and fix
     lost-exception,
     missing-kwoa,
-    missing-param-doc,
+    # missing-param-doc,        # TODO: #210 - enable and fix
     missing-raises-doc,
     mixed-line-endings,
-    no-value-for-parameter,
+    # no-value-for-parameter,   # TODO: #210 - enable and fix
     nonexistent-operator,
     not-in-loop,
-    pointless-statement,
-    redefined-builtin,
+    # pointless-statement,      # TODO: #210 - enable and fix
+    # redefined-builtin,        # TODO: #210 - enable and fix
     return-arg-in-generator,
     return-in-init,
     return-outside-function,
     simplifiable-if-statement,
     singleton-comparison,
     syntax-error,
-    too-many-function-args,
+    # too-many-function-args,   # TODO: #210 - enable and fix
     trailing-whitespace,
     undefined-variable,
-    unexpected-keyword-arg,
+    # unexpected-keyword-arg,   # TODO: #210 - enable and fix
     unhashable-dict-key,
-    unnecessary-pass,
+    # unnecessary-pass,         # TODO: #210 - enable and fix
     unreachable,
     unrecognized-inline-option,
     unused-import,
     unnecessary-semicolon,
-    unused-variable,
-    unused-wildcard-import,
-    wildcard-import,
+    # unused-variable,          # TODO: #210 - enable and fix
+    # unused-wildcard-import,   # TODO: #210 - enable and fix
+    # wildcard-import,          # TODO: #210 - enable and fix
     wrong-or-nonexistent-copyright-notice,
     wrong-import-order,
     wrong-import-position,

--- a/dev_tools/.pylintrc
+++ b/dev_tools/.pylintrc
@@ -2,7 +2,6 @@
 load-plugins=pylint.extensions.docstyle,pylint.extensions.docparams,pylint_copyright_checker
 max-line-length=88
 disable=all
-#ignore-paths=cirq-google/cirq_google/cloud/.*
 ignore-patterns=.*_pb2\.py
 output-format=colorized
 score=no
@@ -15,11 +14,13 @@ enable=
     bad-reversed-sequence,
     bad-super-call,
     consider-merging-isinstance,
+    consider-using-f-string,
     continue-in-finally,
     dangerous-default-value,
     docstyle,
     duplicate-argument-name,
     expression-not-assigned,
+    f-string-without-interpolation,
     function-redefined,
     inconsistent-mro,
     init-is-generator,
@@ -53,6 +54,7 @@ enable=
     unused-variable,
     unused-wildcard-import,
     wildcard-import,
+    wrong-or-nonexistent-copyright-notice,
     wrong-import-order,
     wrong-import-position,
     yield-outside-function

--- a/dev_tools/check_notebooks.py
+++ b/dev_tools/check_notebooks.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/dev_tools/pylint_copyright_checker.py
+++ b/dev_tools/pylint_copyright_checker.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The Cirq Developers
+# Copyright 2024 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ class CopyrightChecker(BaseRawFileChecker):
         if not self.linter.is_message_enabled("wrong-or-nonexistent-copyright-notice"):
             return
         golden = [
-            b'# Copyright 20XX The Cirq Developers',
+            b'# Copyright 20XX The Unitary Authors',
             b'#',
             b'# Licensed under the Apache License, Version 2.0 (the "License");',
             b'# you may not use this file except in compliance with the License.',

--- a/dev_tools/pylint_copyright_checker.py
+++ b/dev_tools/pylint_copyright_checker.py
@@ -1,0 +1,117 @@
+# Copyright 2021 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from astroid import nodes
+from pylint.checkers import BaseRawFileChecker
+
+if TYPE_CHECKING:
+    from pylint.lint import PyLinter
+
+
+class CopyrightChecker(BaseRawFileChecker):
+    """Check for the copyright notices at the beginning of a Python source file.
+
+    This checker can be disabled by putting `# pylint: disable=wrong-or-nonexistent-copyright-notice`
+    at the beginning of a file.
+    """
+
+    name = "copyright-notice"
+    msgs = {
+        "R0001": (
+            "Missing or wrong copyright notice",
+            "wrong-or-nonexistent-copyright-notice",
+            "Consider putting a correct copyright notice at the beginning of a file.",
+        )
+    }
+    options = ()
+
+    def process_module(self, node: nodes.Module) -> None:
+        """Check whether the copyright notice is correctly placed in the source file of a module.
+
+        Compare the first lines of a source file against the standard copyright notice (i.e., the
+        `golden` variable below). Suffix whitespace (including newline symbols) is not considered
+        during the comparison. Pylint will report a message if the copyright notice is not
+        correctly placed.
+
+        Args:
+            node: the module to be checked.
+        """
+        # Exit if the checker is disabled in the source file.
+        if not self.linter.is_message_enabled("wrong-or-nonexistent-copyright-notice"):
+            return
+        golden = [
+            b'# Copyright 20XX The Cirq Developers',
+            b'#',
+            b'# Licensed under the Apache License, Version 2.0 (the "License");',
+            b'# you may not use this file except in compliance with the License.',
+            b'# You may obtain a copy of the License at',
+            b'#',
+            b'#     https://www.apache.org/licenses/LICENSE-2.0',
+            b'#',
+            b'# Unless required by applicable law or agreed to in writing, software',
+            b'# distributed under the License is distributed on an "AS IS" BASIS,',
+            b'# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.',
+            b'# See the License for the specific language governing permissions and',
+            b'# limitations under the License.',
+        ]
+        with node.stream() as stream:
+
+            def skip_shebang(stream):
+                """Skip shebang line if present, and blank lines between shebang and content."""
+                lines = iter(enumerate(stream))
+                try:
+                    lineno, line = next(lines)
+                except StopIteration:
+                    return
+                if line.startswith(b'#!'):
+                    # skip shebang and blank lines
+                    for lineno, line in lines:
+                        if line.strip():
+                            yield lineno, line
+                            break
+                else:
+                    # no shebang
+                    yield lineno, line
+                yield from lines
+
+            for expected_line, (i, (lineno, line)) in zip(golden, enumerate(skip_shebang(stream))):
+                for expected_char, (colno, char) in zip(expected_line, enumerate(line)):
+                    # The text needs to be same as the template except for the year.
+                    if expected_char != char and not (i == 0 and 14 <= colno <= 15):
+                        self.add_message(
+                            "wrong-or-nonexistent-copyright-notice",
+                            line=lineno + 1,
+                            col_offset=colno,
+                        )
+                        return
+                # The line cannot be shorter than the template or contain extra text.
+                if len(line) < len(expected_line) or line[len(expected_line) :].strip() != b'':
+                    self.add_message(
+                        "wrong-or-nonexistent-copyright-notice",
+                        line=lineno + 1,
+                        col_offset=min(len(line), len(expected_line)),
+                    )
+                    return
+
+
+def register(linter: PyLinter):
+    """Register this checker to pylint.
+
+    The registration is done automatically if this file is in $PYTHONPATH.
+    """
+    linter.register_checker(CopyrightChecker(linter))

--- a/dev_tools/write-ci-requirements.py
+++ b/dev_tools/write-ci-requirements.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/fox_in_a_hole/fox_in_a_hole.py
+++ b/examples/fox_in_a_hole/fox_in_a_hole.py
@@ -15,11 +15,12 @@
 """Classical and quantum Fox-in-a-hole game."""
 
 import abc
+import argparse
 import sys
 import enum
-import numpy as np
-import argparse
 from typing import Optional
+
+import numpy as np
 
 from unitary.alpha import (
     QuantumObject,

--- a/examples/fox_in_a_hole/fox_in_a_hole.py
+++ b/examples/fox_in_a_hole/fox_in_a_hole.py
@@ -358,19 +358,19 @@ if __name__ == "__main__":
 
     # Initialize game object
 
-    print(f"---------------------------------")
+    print("---------------------------------")
     if args.is_quantum or (args.qprob is not None and args.qprob > 0.0):
         game: Game = QuantumGame(qprob=args.qprob, iswap=args.use_iswap)
-        print(f"Quantum Fox-in-a-hole game.")
+        print("Quantum Fox-in-a-hole game.")
         print(f"Probability of quantum move: {game.qprob}.")
         if args.use_iswap:
-            print(f"Using iSWAP for moves.")
+            print("Using iSWAP for moves.")
         else:
-            print(f"Using SWAP for moves.")
+            print("Using SWAP for moves.")
     else:
         game = ClassicalGame()
         print("Classical Fox-in-a-hole game.")
-    print(f"---------------------------------")
+    print("---------------------------------")
 
     # Run Fox-in-a-hole
     game.run()

--- a/examples/fox_in_a_hole/fox_in_a_hole_test.py
+++ b/examples/fox_in_a_hole/fox_in_a_hole_test.py
@@ -14,8 +14,6 @@
 
 """Tests for ClassicalGame and QuantumGame classes."""
 
-import pytest
-
 from . import fox_in_a_hole as fh
 
 

--- a/examples/quantum_chinese_chess/__init__.py
+++ b/examples/quantum_chinese_chess/__init__.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_chinese_chess/board.py
+++ b/examples/quantum_chinese_chess/board.py
@@ -64,8 +64,7 @@ class Board:
 
     @classmethod
     def from_fen(cls, fen: str = _INITIAL_FEN) -> "Board":
-        """
-        Translates FEN (Forsyth-Edwards Notation) symbols into the whole QuantumWorld board.
+        """Translates FEN (Forsyth-Edwards Notation) symbols into the whole QuantumWorld board.
         FEN rule for Chinese Chess could be found at https://www.wxf-xiangqi.org/images/computer-xiangqi/fen-for-xiangqi-chinese-chess.pdf
         """
         chess_board = {}
@@ -113,8 +112,7 @@ class Board:
         probabilities: List[float] = None,
         peek_result: List[int] = None,
     ) -> str:
-        """
-        Print the board into string.
+        """Print the board into string.
 
         Args:
             terminal: type of the terminal that the game is currently running on;

--- a/examples/quantum_chinese_chess/board.py
+++ b/examples/quantum_chinese_chess/board.py
@@ -11,8 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import numpy as np
+
 from typing import List, Tuple
+
+import numpy as np
+
 import unitary.alpha as alpha
 from .enums import (
     SquareState,

--- a/examples/quantum_chinese_chess/board_test.py
+++ b/examples/quantum_chinese_chess/board_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 from .enums import (
     Language,
     Color,
@@ -25,7 +25,6 @@ from .test_utils import (
     locations_to_bitboard,
     assert_samples_in,
     assert_sample_distribution,
-    get_board_probability_distribution,
     set_board,
 )
 from unitary import alpha

--- a/examples/quantum_chinese_chess/board_test.py
+++ b/examples/quantum_chinese_chess/board_test.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
+from unitary import alpha
 from .enums import (
     Language,
     Color,
@@ -27,8 +30,6 @@ from .test_utils import (
     assert_sample_distribution,
     set_board,
 )
-from unitary import alpha
-import re
 
 
 def test_init_with_default_fen():

--- a/examples/quantum_chinese_chess/board_test.py
+++ b/examples/quantum_chinese_chess/board_test.py
@@ -170,16 +170,16 @@ def test_flying_general_check_classical_cases():
     board = Board.from_fen()
     # If they are in different columns, the check fails.
     board.king_locations = ["d0", "e9"]
-    assert board.flying_general_check() == False
+    assert not board.flying_general_check()
 
     # If there are classical pieces between two KINGs, the check fails.
     board.king_locations = ["e0", "e9"]
-    assert board.flying_general_check() == False
+    assert not board.flying_general_check()
 
     # If there are no pieces between two KINGs, the check successes.
     board.board["e3"].reset()
     board.board["e6"].reset()
-    assert board.flying_general_check() == True
+    assert board.flying_general_check()
 
 
 def test_flying_general_check_quantum_cases():

--- a/examples/quantum_chinese_chess/chess.py
+++ b/examples/quantum_chinese_chess/chess.py
@@ -138,7 +138,7 @@ class QuantumChineseChess:
         for location in sources + targets:
             if location[0].lower() not in "abcdefghi" or not location[1].isdigit():
                 raise ValueError(
-                    f"Invalid location string. Make sure they are from a0 to i9."
+                    "Invalid location string. Make sure they are from a0 to i9."
                 )
         return sources, targets
 

--- a/examples/quantum_chinese_chess/chess.py
+++ b/examples/quantum_chinese_chess/chess.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from typing import Tuple, List
 from .board import Board
 from .enums import (
@@ -31,7 +32,6 @@ from .move import (
     MergeSlide,
     CannonFire,
 )
-import readline
 
 # List of acceptable commands.
 _HELP_TEXT = """

--- a/examples/quantum_chinese_chess/chess_test.py
+++ b/examples/quantum_chinese_chess/chess_test.py
@@ -11,16 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import pytest
+
 import io
 import sys
+
+import pytest
+
+from unitary import alpha
 from .test_utils import (
     set_board,
     assert_sample_distribution,
     locations_to_bitboard,
     assert_samples_in,
 )
-from unitary import alpha
 from .chess import QuantumChineseChess
 from .piece import Piece
 from .enums import (

--- a/examples/quantum_chinese_chess/chess_test.py
+++ b/examples/quantum_chinese_chess/chess_test.py
@@ -386,12 +386,12 @@ def test_update_board_by_sampling(monkeypatch):
     game.update_board_by_sampling()
     assert board["a0"].type_ == Type.EMPTY
     assert board["a0"].color == Color.NA
-    assert board["a0"].is_entangled == False
+    assert not board["a0"].is_entangled
 
     board["a1"].is_entangled = True
     # Verify that the method would set a1 to classically occupied.
     game.update_board_by_sampling()
-    assert board["a1"].is_entangled == False
+    assert not board["a1"].is_entangled
 
 
 def test_undo_single_effect_per_move(monkeypatch):

--- a/examples/quantum_chinese_chess/enums.py
+++ b/examples/quantum_chinese_chess/enums.py
@@ -4,13 +4,14 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import enum
 from typing import Optional
 

--- a/examples/quantum_chinese_chess/enums_test.py
+++ b/examples/quantum_chinese_chess/enums_test.py
@@ -4,13 +4,14 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from .enums import Type, Color, Language
 
 

--- a/examples/quantum_chinese_chess/enums_test.py
+++ b/examples/quantum_chinese_chess/enums_test.py
@@ -21,7 +21,7 @@ def test_type_of():
     assert Type.type_of("k") == Type.KING
     assert Type.type_of("K") == Type.KING
     assert Type.type_of("·") == Type.EMPTY
-    assert Type.type_of("b") == None
+    assert Type.type_of("b") is None
 
 
 def test_symbol():

--- a/examples/quantum_chinese_chess/move.py
+++ b/examples/quantum_chinese_chess/move.py
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional, List, Tuple, Iterator
+
+from typing import Optional, List, Iterator
 import cirq
 from unitary import alpha
 from unitary.alpha.quantum_effect import QuantumEffect

--- a/examples/quantum_chinese_chess/move_test.py
+++ b/examples/quantum_chinese_chess/move_test.py
@@ -80,7 +80,7 @@ def test_move_type():
         move_type=MoveType.MERGE_JUMP,
         move_variant=MoveVariant.CAPTURE,
     )
-    assert move1.is_split_move() == False
+    assert not move1.is_split_move()
     assert move1.is_merge_move()
 
     move2 = Move(
@@ -91,7 +91,7 @@ def test_move_type():
         move_variant=MoveVariant.BASIC,
     )
     assert move2.is_split_move()
-    assert move2.is_merge_move() == False
+    assert not move2.is_merge_move()
 
     move3 = Move(
         world["a1"],
@@ -99,8 +99,8 @@ def test_move_type():
         move_type=MoveType.SLIDE,
         move_variant=MoveVariant.CAPTURE,
     )
-    assert move3.is_split_move() == False
-    assert move3.is_merge_move() == False
+    assert not move3.is_split_move()
+    assert not move3.is_merge_move()
 
 
 def test_to_str():
@@ -275,10 +275,10 @@ def test_split_jump_classical_source():
     assert_fifty_fifty(board_probabilities, locations_to_bitboard(["a3"]))
     assert world["a2"].type_ == Type.ROOK
     assert world["a2"].color == Color.RED
-    assert world["a2"].is_entangled == True
+    assert world["a2"].is_entangled
     assert world["a3"].type_ == Type.ROOK
     assert world["a3"].color == Color.RED
-    assert world["a3"].is_entangled == True
+    assert world["a3"].is_entangled
 
 
 def test_split_jump_quantum_source():
@@ -295,8 +295,8 @@ def test_split_jump_quantum_source():
             locations_to_bitboard(["a5"]): 0.25,
         },
     )
-    assert world["a4"].is_entangled == True
-    assert world["a5"].is_entangled == True
+    assert world["a4"].is_entangled
+    assert world["a5"].is_entangled
 
 
 def test_merge_jump_perfect_merge():

--- a/examples/quantum_chinese_chess/move_test.py
+++ b/examples/quantum_chinese_chess/move_test.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List
 
-import pytest
 from unitary import alpha
 
 from .move import *
@@ -22,7 +20,6 @@ from .piece import Piece
 from .enums import (
     MoveType,
     MoveVariant,
-    SquareState,
     Type,
     Color,
 )
@@ -30,11 +27,8 @@ from .test_utils import (
     locations_to_bitboard,
     assert_samples_in,
     assert_sample_distribution,
-    assert_this_or_that,
-    assert_prob_about,
     assert_fifty_fifty,
     get_board_probability_distribution,
-    print_samples,
     set_board,
 )
 

--- a/examples/quantum_chinese_chess/piece.py
+++ b/examples/quantum_chinese_chess/piece.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
+
 from unitary.alpha import QuantumObject
 from .enums import (
     SquareState,

--- a/examples/quantum_chinese_chess/piece_test.py
+++ b/examples/quantum_chinese_chess/piece_test.py
@@ -58,7 +58,7 @@ def test_reset():
     p0.reset()
     assert p0.type_ == Type.EMPTY
     assert p0.color == Color.NA
-    assert p0.is_entangled == False
+    assert not p0.is_entangled
 
     p0.reset(p1)
     assert p0.type_ == p1.type_

--- a/examples/quantum_chinese_chess/piece_test.py
+++ b/examples/quantum_chinese_chess/piece_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 from unitary.alpha import QuantumWorld
 
 from .enums import (

--- a/examples/quantum_chinese_chess/test_utils.py
+++ b/examples/quantum_chinese_chess/test_utils.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_chinese_chess/test_utils.py
+++ b/examples/quantum_chinese_chess/test_utils.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from typing import List, Dict
 from collections import defaultdict
 
 from scipy.stats import chisquare
 from unitary import alpha
-from unitary.alpha import QuantumObject, QuantumWorld
 
 from .enums import SquareState, Type, Color
 from .board import Board

--- a/examples/quantum_rpg/__init__.py
+++ b/examples/quantum_rpg/__init__.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/ascii_art.py
+++ b/examples/quantum_rpg/ascii_art.py
@@ -1,3 +1,17 @@
+# Copyright 2023 The Unitary Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """ASCII art and other large text constants."""
 
 # ASCII art generated with font

--- a/examples/quantum_rpg/battle.py
+++ b/examples/quantum_rpg/battle.py
@@ -4,13 +4,14 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import enum
 from typing import List, Optional, Set
 

--- a/examples/quantum_rpg/battle_test.py
+++ b/examples/quantum_rpg/battle_test.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/bb84.py
+++ b/examples/quantum_rpg/bb84.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/bb84.py
+++ b/examples/quantum_rpg/bb84.py
@@ -11,13 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from typing import Tuple
 import random
 import re
 
 from .game_state import GameState
-from .item import EXAMINE, TALK, Item
-from .world import Direction, Location
+from .item import EXAMINE, Item
+from .world import Direction
 
 
 _WORDS = [

--- a/examples/quantum_rpg/bb84.py
+++ b/examples/quantum_rpg/bb84.py
@@ -105,7 +105,7 @@ def _view_alice(state: GameState, world):
         return "The display reads 'Ready to TRANSMIT'"
     if state.state_dict["astatus"] == "success":
         return f"The display reads 'Transmission Successful:'\n'{state.state_dict['alice']}'"
-    return f"The display reads 'Error transmitting data.'"
+    return "The display reads 'Error transmitting data.'"
 
 
 def _view_bob(state: GameState, world):
@@ -115,7 +115,7 @@ def _view_bob(state: GameState, world):
         return "The display reads 'Ready to Receive'"
     if state.state_dict["bstatus"] == "success":
         return f"The display reads 'Received data:'\n'{state.state_dict['bob']}'"
-    return f"The display reads 'Error receiving data.'"
+    return "The display reads 'Error receiving data.'"
 
 
 def _power_on_alice(state: GameState, world):

--- a/examples/quantum_rpg/bb84_test.py
+++ b/examples/quantum_rpg/bb84_test.py
@@ -4,13 +4,14 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from typing import cast
 import io
 

--- a/examples/quantum_rpg/bb84_test.py
+++ b/examples/quantum_rpg/bb84_test.py
@@ -166,7 +166,7 @@ The keypad beeps and a light flashes red.
     loop.loop()
     assert (
         cast(io.StringIO, state.file).getvalue().replace("\t", " ").strip()
-        == f"""
+        == """
 Quantum Communication Receiving Facility
 
 

--- a/examples/quantum_rpg/classes.py
+++ b/examples/quantum_rpg/classes.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/classes_test.py
+++ b/examples/quantum_rpg/classes_test.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/encounter.py
+++ b/examples/quantum_rpg/encounter.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/encounter.py
+++ b/examples/quantum_rpg/encounter.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
 from typing import Optional, Sequence
 
 import random

--- a/examples/quantum_rpg/encounter_test.py
+++ b/examples/quantum_rpg/encounter_test.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/encounter_test.py
+++ b/examples/quantum_rpg/encounter_test.py
@@ -16,7 +16,6 @@ import io
 
 import unitary.alpha as alpha
 
-from . import battle
 from . import classes
 from . import encounter
 from . import game_state

--- a/examples/quantum_rpg/enums.py
+++ b/examples/quantum_rpg/enums.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/exceptions.py
+++ b/examples/quantum_rpg/exceptions.py
@@ -4,13 +4,14 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Exceptions used in Quantum RPG."""
 
 

--- a/examples/quantum_rpg/final_state_preparation/__init__.py
+++ b/examples/quantum_rpg/final_state_preparation/__init__.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/final_state_preparation/classical_frontier.py
+++ b/examples/quantum_rpg/final_state_preparation/classical_frontier.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/final_state_preparation/classical_frontier.py
+++ b/examples/quantum_rpg/final_state_preparation/classical_frontier.py
@@ -11,10 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import unitary.alpha as alpha
 
 from ..classes import Engineer
-from ..encounter import Encounter
 from ..exceptions import UntimelyDeathException
 from ..game_state import GameState
 from .monsters import (

--- a/examples/quantum_rpg/final_state_preparation/final_state_world.py
+++ b/examples/quantum_rpg/final_state_preparation/final_state_world.py
@@ -4,13 +4,14 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Module to combine all the zones of the RPG world into one list."""
 
 from . import classical_frontier

--- a/examples/quantum_rpg/final_state_preparation/final_state_world_test.py
+++ b/examples/quantum_rpg/final_state_preparation/final_state_world_test.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Various consistency checks to make sure the world is correctly built."""
-import pytest
+
 import io
+
+import pytest
 
 from .. import classes
 from .. import exceptions

--- a/examples/quantum_rpg/final_state_preparation/final_state_world_test.py
+++ b/examples/quantum_rpg/final_state_preparation/final_state_world_test.py
@@ -4,13 +4,14 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Various consistency checks to make sure the world is correctly built."""
 
 import io

--- a/examples/quantum_rpg/final_state_preparation/hadamard_hills.py
+++ b/examples/quantum_rpg/final_state_preparation/hadamard_hills.py
@@ -4,13 +4,14 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import unitary.alpha as alpha
 
 from ..bb84 import ALICE, BOB, DOOR

--- a/examples/quantum_rpg/final_state_preparation/monsters.py
+++ b/examples/quantum_rpg/final_state_preparation/monsters.py
@@ -4,13 +4,14 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import unitary.alpha as alpha
 
 from ..encounter import Encounter

--- a/examples/quantum_rpg/final_state_preparation/oxtail_university.py
+++ b/examples/quantum_rpg/final_state_preparation/oxtail_university.py
@@ -4,13 +4,14 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import unitary.alpha as alpha
 
 from ..classes import Engineer

--- a/examples/quantum_rpg/final_state_preparation/oxtail_university.py
+++ b/examples/quantum_rpg/final_state_preparation/oxtail_university.py
@@ -36,7 +36,7 @@ from ..world import Direction, Location
 
 def _engineer_joins(state: GameState, world) -> str:
     if len(state.party) > 1:
-        return f"The engineer reminisces about his former experiment."
+        return "The engineer reminisces about his former experiment."
     print(
         "The engineer looks at the apparatus that dominates the room.", file=state.file
     )

--- a/examples/quantum_rpg/final_state_preparation/quantum_perimeter.py
+++ b/examples/quantum_rpg/final_state_preparation/quantum_perimeter.py
@@ -1,3 +1,17 @@
+# Copyright 2023 The Unitary Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from ..item import EXAMINE, Item
 from ..world import Direction, Location
 

--- a/examples/quantum_rpg/game_state.py
+++ b/examples/quantum_rpg/game_state.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/game_state.py
+++ b/examples/quantum_rpg/game_state.py
@@ -14,7 +14,6 @@
 
 from typing import Dict, List, Optional, Sequence, TextIO
 
-import io
 import sys
 
 from . import input_helpers

--- a/examples/quantum_rpg/game_state_test.py
+++ b/examples/quantum_rpg/game_state_test.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/input_helpers.py
+++ b/examples/quantum_rpg/input_helpers.py
@@ -1,3 +1,17 @@
+# Copyright 2023 The Unitary Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Functions for safe and user-friendly input."""
 
 from typing import Callable, Optional, Sequence, TextIO, Union

--- a/examples/quantum_rpg/input_helpers_test.py
+++ b/examples/quantum_rpg/input_helpers_test.py
@@ -1,3 +1,17 @@
+# Copyright 2023 The Unitary Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import io
 
 import pytest

--- a/examples/quantum_rpg/item.py
+++ b/examples/quantum_rpg/item.py
@@ -1,3 +1,17 @@
+# Copyright 2023 The Unitary Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import re
 from typing import Any, Callable, Optional, Sequence, Tuple, Union
 

--- a/examples/quantum_rpg/item_test.py
+++ b/examples/quantum_rpg/item_test.py
@@ -1,3 +1,17 @@
+# Copyright 2023 The Unitary Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import re
 
 from . import item

--- a/examples/quantum_rpg/main_loop.py
+++ b/examples/quantum_rpg/main_loop.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/main_loop.py
+++ b/examples/quantum_rpg/main_loop.py
@@ -13,10 +13,8 @@
 # limitations under the License.
 
 import enum
-import io
-import sys
 import textwrap
-from typing import List, Optional, Sequence
+from typing import Optional, Sequence
 
 from . import ascii_art
 from . import battle

--- a/examples/quantum_rpg/main_loop_test.py
+++ b/examples/quantum_rpg/main_loop_test.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/main_loop_test.py
+++ b/examples/quantum_rpg/main_loop_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import copy
+
 import io
 from typing import cast
 

--- a/examples/quantum_rpg/npcs.py
+++ b/examples/quantum_rpg/npcs.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/npcs.py
+++ b/examples/quantum_rpg/npcs.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from typing import cast, List
 
 import random
 
 import unitary.alpha as alpha
 
-from . import enums
 from . import qaracter
 
 

--- a/examples/quantum_rpg/npcs_test.py
+++ b/examples/quantum_rpg/npcs_test.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/npcs_test.py
+++ b/examples/quantum_rpg/npcs_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unitary.alpha as alpha
-
 from . import battle
 from . import classes
 from . import enums

--- a/examples/quantum_rpg/qaracter.py
+++ b/examples/quantum_rpg/qaracter.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/qaracter.py
+++ b/examples/quantum_rpg/qaracter.py
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import cast, Callable, Dict, List, Optional, Union
+
+from typing import cast, Dict, List, Optional, Union
 import inspect
-import random
 import sys
 
 import cirq

--- a/examples/quantum_rpg/qaracter_test.py
+++ b/examples/quantum_rpg/qaracter_test.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/world.py
+++ b/examples/quantum_rpg/world.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/world_test.py
+++ b/examples/quantum_rpg/world_test.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/world_test.py
+++ b/examples/quantum_rpg/world_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import item
 from . import world
 
 

--- a/examples/quantum_rpg/xp_utils.py
+++ b/examples/quantum_rpg/xp_utils.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/quantum_rpg/xp_utils.py
+++ b/examples/quantum_rpg/xp_utils.py
@@ -14,9 +14,7 @@
 
 from typing import List, Optional, Sequence
 
-import io
 import random
-import sys
 
 import unitary.alpha as alpha
 

--- a/examples/quantum_rpg/xp_utils_test.py
+++ b/examples/quantum_rpg/xp_utils_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 import io
 
 import cirq

--- a/examples/tic_tac_toe/enums.py
+++ b/examples/tic_tac_toe/enums.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 from typing import Union
 import enum
 

--- a/examples/tic_tac_toe/tic_tac_split.py
+++ b/examples/tic_tac_toe/tic_tac_split.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 from typing import Optional
 
 import numpy as np
 import cirq
 
-from unitary.alpha import QuantumEffect, QuantumObject
+from unitary.alpha import QuantumEffect
 from unitary.alpha.qudit_gates import QuditXGate, QuditISwapPowGate
 
 from .enums import TicTacSquare, TicTacRules

--- a/examples/tic_tac_toe/tic_tac_split.py
+++ b/examples/tic_tac_toe/tic_tac_split.py
@@ -71,8 +71,7 @@ class QuditSplitGate(cirq.Gate):
 
 
 class TicTacSplit(QuantumEffect):
-    """
-    Flips a qubit from |0> to |1> then splits to another square.
+    """Flips a qubit from |0> to |1> then splits to another square.
     Depending on the ruleset, the split is done either using a standard
     sqrt-ISWAP gate, or using the custom QuditSplitGate.
     """

--- a/examples/tic_tac_toe/tic_tac_split_test.py
+++ b/examples/tic_tac_toe/tic_tac_split_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 import pytest
 
 import cirq

--- a/examples/tic_tac_toe/tic_tac_toe.py
+++ b/examples/tic_tac_toe/tic_tac_toe.py
@@ -260,8 +260,7 @@ class TicTacToe:
 
 
 class GameInterface:
-    """
-    A class that provides a command-line interface to play Quantum Tic Tac Toe.
+    """A class that provides a command-line interface to play Quantum Tic Tac Toe.
 
     Initialize by providing an instance of a TicTacToe game, then call play()
     to run the game.
@@ -281,16 +280,14 @@ class GameInterface:
         self.player_quit = False
 
     def get_move(self) -> str:
-        """
-        Gets and returns the player's move.
+        """Gets and returns the player's move.
 
         Basically a wrapper around input to facilitate testing.
         """
         return input(f'Player {self.player} to move ("help" for help): ')
 
     def player_move(self) -> None:
-        """
-        Interprets the player's move and takes the appropriate action.
+        """Interprets the player's move and takes the appropriate action.
 
         A move can be a one or two letter string within the set [abcdefghi],
         in which case this function hands the move off to the TicTacToe instance,
@@ -318,8 +315,7 @@ class GameInterface:
         self.player = "O" if self.player == "X" else "X"
 
     def print_welcome(self) -> str:
-        """
-        Prints the welcome message for the game interface.
+        """Prints the welcome message for the game interface.
         """
         message = """
         Welcome to quantum tic tac toe!
@@ -329,8 +325,7 @@ class GameInterface:
         return message
 
     def play(self) -> None:
-        """
-        Run the game loop, requesting player moves, alternating players, until
+        """Run the game loop, requesting player moves, alternating players, until
         the TicTacToe instance reports that the game ends with a winner or a tie
         or one of the players has quit.
         """

--- a/examples/tic_tac_toe/tic_tac_toe.py
+++ b/examples/tic_tac_toe/tic_tac_toe.py
@@ -202,7 +202,7 @@ class TicTacToe:
             # Check if rules allow quantum moves
             if self.rules == TicTacRules.CLASSICAL:
                 raise ValueError(
-                    f"Quantum moves are not allowed in a classical TicTacToe"
+                    "Quantum moves are not allowed in a classical TicTacToe"
                 )
 
             # Check if either square is non-empty. Splitting on top of

--- a/examples/tic_tac_toe/tic_tac_toe.py
+++ b/examples/tic_tac_toe/tic_tac_toe.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import io
+
 import sys
 from typing import Dict, List, TextIO
 

--- a/examples/tic_tac_toe/tic_tac_toe_test.py
+++ b/examples/tic_tac_toe/tic_tac_toe_test.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import io
 from unittest.mock import MagicMock
+
+import pytest
 
 from . import enums
 from . import tic_tac_toe

--- a/examples/tic_tac_toe/tic_tac_toe_test.py
+++ b/examples/tic_tac_toe/tic_tac_toe_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
+
 import pytest
 import io
 from unittest.mock import MagicMock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 88
+target_version = ['py310', 'py311', 'py312']

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unitary/__init__.py
+++ b/unitary/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unitary/_version.py
+++ b/unitary/_version.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unitary/alpha/__init__.py
+++ b/unitary/alpha/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from unitary.alpha.qudit_state_transform import (
     qubit_to_qudit_state,

--- a/unitary/alpha/quantum_effect.py
+++ b/unitary/alpha/quantum_effect.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 from typing import Iterator, Optional, Sequence, Union, TYPE_CHECKING
 import abc
 import enum

--- a/unitary/alpha/quantum_effect_test.py
+++ b/unitary/alpha/quantum_effect_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 import pytest
 
 import cirq

--- a/unitary/alpha/quantum_object_test.py
+++ b/unitary/alpha/quantum_object_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 import enum
 import pytest
 

--- a/unitary/alpha/quantum_world.py
+++ b/unitary/alpha/quantum_world.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import copy
 import enum
 from typing import cast, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
@@ -20,7 +21,6 @@ from unitary.alpha.quantum_object import QuantumObject
 from unitary.alpha.sparse_vector_simulator import PostSelectOperation, SparseSimulator
 from unitary.alpha.qudit_state_transform import qudit_to_qubit_unitary, num_bits
 import numpy as np
-import itertools
 
 
 class QuantumWorld:

--- a/unitary/alpha/quantum_world.py
+++ b/unitary/alpha/quantum_world.py
@@ -15,12 +15,13 @@
 import copy
 import enum
 from typing import cast, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
+
 import cirq
+import numpy as np
 
 from unitary.alpha.quantum_object import QuantumObject
 from unitary.alpha.sparse_vector_simulator import PostSelectOperation, SparseSimulator
 from unitary.alpha.qudit_state_transform import qudit_to_qubit_unitary, num_bits
-import numpy as np
 
 
 class QuantumWorld:

--- a/unitary/alpha/quantum_world_test.py
+++ b/unitary/alpha/quantum_world_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 import enum
 
 import pytest

--- a/unitary/alpha/quantum_world_test.py
+++ b/unitary/alpha/quantum_world_test.py
@@ -51,7 +51,7 @@ def test_get_object_by_name(compile_to_qubits):
     board = alpha.QuantumWorld([light, light2], compile_to_qubits=compile_to_qubits)
     assert board.get_object_by_name("test") == light
     assert board.get_object_by_name("test2") == light2
-    assert board.get_object_by_name("test3") == None
+    assert board.get_object_by_name("test3") is None
     assert board["test"] == light
     assert board["test2"] == light2
     with pytest.raises(KeyError):

--- a/unitary/alpha/qubit_effects.py
+++ b/unitary/alpha/qubit_effects.py
@@ -11,10 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-from typing import Iterator, Optional, Sequence, Union
-import abc
-import enum
+
+from typing import Optional
 
 import cirq
 

--- a/unitary/alpha/qubit_effects_test.py
+++ b/unitary/alpha/qubit_effects_test.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import enum
 import pytest

--- a/unitary/alpha/qudit_effects.py
+++ b/unitary/alpha/qudit_effects.py
@@ -11,10 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-from typing import Iterator, Optional, Sequence, Union
-import abc
-import enum
 
 import cirq
 

--- a/unitary/alpha/qudit_effects_test.py
+++ b/unitary/alpha/qudit_effects_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 import enum
 import pytest
 

--- a/unitary/alpha/qudit_gates.py
+++ b/unitary/alpha/qudit_gates.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-
 
 from typing import List, Dict, Optional, Tuple
 

--- a/unitary/alpha/qudit_gates_test.py
+++ b/unitary/alpha/qudit_gates_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 import pytest
 import numpy as np
 import cirq

--- a/unitary/alpha/qudit_state_transform.py
+++ b/unitary/alpha/qudit_state_transform.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 import itertools
 
 import numpy as np

--- a/unitary/alpha/qudit_state_transform_test.py
+++ b/unitary/alpha/qudit_state_transform_test.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/unitary/alpha/quokka_sampler.py
+++ b/unitary/alpha/quokka_sampler.py
@@ -4,13 +4,14 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Simulation using a "Quokka" device."""
 
 import json

--- a/unitary/alpha/quokka_sampler.py
+++ b/unitary/alpha/quokka_sampler.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 """Simulation using a "Quokka" device."""
 
-from typing import Any, Callable, Dict, Optional, Sequence
+import json
 import warnings
+from typing import Any, Callable, Dict, Optional, Sequence
 
 import cirq
 import numpy as np
-import json
 
 _REQUEST_ENDPOINT = "http://{}.quokkacomputing.com/qsim/qasm"
 _DEFAULT_QUOKKA_NAME = "quokka1"

--- a/unitary/alpha/quokka_sampler_test.py
+++ b/unitary/alpha/quokka_sampler_test.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/unitary/alpha/sparse_vector_simulator.py
+++ b/unitary/alpha/sparse_vector_simulator.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/unitary/alpha/sparse_vector_simulator.py
+++ b/unitary/alpha/sparse_vector_simulator.py
@@ -20,6 +20,7 @@ Supports standard unitary Cirq gates, plus a post-selection operator.
 
 Does not work with 3+-state qudits.
 """
+
 import cirq
 import numpy as np
 

--- a/unitary/alpha/sparse_vector_simulator_test.py
+++ b/unitary/alpha/sparse_vector_simulator_test.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/unitary/engine_utils.py
+++ b/unitary/engine_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unitary/engine_utils_test.py
+++ b/unitary/engine_utils_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unitary/quantum_chess/__init__.py
+++ b/unitary/quantum_chess/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unitary/quantum_chess/ascii_board.py
+++ b/unitary/quantum_chess/ascii_board.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/unitary/quantum_chess/ascii_board.py
+++ b/unitary/quantum_chess/ascii_board.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from typing import Optional, Sequence
+from typing import Sequence
 
 import unitary.quantum_chess.bit_utils as bu
 import unitary.quantum_chess.constants as c

--- a/unitary/quantum_chess/ascii_board_test.py
+++ b/unitary/quantum_chess/ascii_board_test.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/unitary/quantum_chess/bit_utils.py
+++ b/unitary/quantum_chess/bit_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Utilities for converting to and from bit boards.
 """

--- a/unitary/quantum_chess/bit_utils.py
+++ b/unitary/quantum_chess/bit_utils.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Utilities for converting to and from bit boards.
-"""
+"""Utilities for converting to and from bit boards."""
+
 from typing import List
 
 import cirq

--- a/unitary/quantum_chess/bit_utils_test.py
+++ b/unitary/quantum_chess/bit_utils_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import cirq
 
 import unitary.quantum_chess.bit_utils as u

--- a/unitary/quantum_chess/caching_utils.py
+++ b/unitary/quantum_chess/caching_utils.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/unitary/quantum_chess/circuit_transformer.py
+++ b/unitary/quantum_chess/circuit_transformer.py
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import copy
 from typing import Dict, Iterable, List, Optional, Sequence, Set
 
 import cirq
-import cirq_google as cg
 
 import unitary.quantum_chess.controlled_iswap as controlled_iswap
 import unitary.quantum_chess.initial_mapping_utils as imu

--- a/unitary/quantum_chess/circuit_transformer.py
+++ b/unitary/quantum_chess/circuit_transformer.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unitary/quantum_chess/circuit_transformer_test.py
+++ b/unitary/quantum_chess/circuit_transformer_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import pytest
 import cirq
 import cirq_google as cg

--- a/unitary/quantum_chess/circuit_transformer_test.py
+++ b/unitary/quantum_chess/circuit_transformer_test.py
@@ -51,8 +51,7 @@ def test_qubits_within(device):
 
 @pytest.mark.parametrize("device", (cg.Sycamore23, cg.Sycamore))
 def test_edges_within(device):
-    """
-    The circuit looks like:
+    """The circuit looks like:
 
     a1 --- a4 --- a3 --- a2      d1
            |      |      |

--- a/unitary/quantum_chess/constants.py
+++ b/unitary/quantum_chess/constants.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import cirq
 
 PIECES = {

--- a/unitary/quantum_chess/controlled_iswap.py
+++ b/unitary/quantum_chess/controlled_iswap.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from typing import Sequence, Union, Optional
 
 import cirq
-import cirq_google as cg
 import numpy as np
 from cirq.transformers.analytical_decompositions.two_qubit_to_fsim import (
     _decompose_xx_yy_into_two_fsims_ignoring_single_qubit_ops,

--- a/unitary/quantum_chess/controlled_iswap.py
+++ b/unitary/quantum_chess/controlled_iswap.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unitary/quantum_chess/controlled_iswap_test.py
+++ b/unitary/quantum_chess/controlled_iswap_test.py
@@ -11,9 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import cirq
-import unitary.quantum_chess.controlled_iswap as controlled_iswap
 import numpy as np
+
+import unitary.quantum_chess.controlled_iswap as controlled_iswap
 
 
 def test_controlled_iswap():

--- a/unitary/quantum_chess/controlled_iswap_test.py
+++ b/unitary/quantum_chess/controlled_iswap_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unitary/quantum_chess/enums.py
+++ b/unitary/quantum_chess/enums.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import enum
 
 

--- a/unitary/quantum_chess/experiments/__init__.py
+++ b/unitary/quantum_chess/experiments/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unitary/quantum_chess/experiments/batch_moves.py
+++ b/unitary/quantum_chess/experiments/batch_moves.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/unitary/quantum_chess/experiments/batch_moves.py
+++ b/unitary/quantum_chess/experiments/batch_moves.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Runs a series of moves on a quantum chess board then displays the
-result.
+"""Runs a series of moves on a quantum chess board then displays the result.
 
 Run with:
   python -m unitary.quantum_chess.experiments.batch_moves \
@@ -32,6 +30,7 @@ noiseless simulator if none are available.
 FEN is a initial position in chess FEN notation. Optional.
 Default is the normal classical chess starting position.
 """
+
 import argparse
 from typing import List
 

--- a/unitary/quantum_chess/experiments/batch_moves.py
+++ b/unitary/quantum_chess/experiments/batch_moves.py
@@ -77,7 +77,7 @@ def main_loop(args):
         b.load_fen(args.position)
     else:
         b.reset()
-    print(f"Applying moves to board...")
+    print("Applying moves to board...")
     apply_moves(b, moves)
     print(b)
 

--- a/unitary/quantum_chess/experiments/circuit_transform_benchmark.py
+++ b/unitary/quantum_chess/experiments/circuit_transform_benchmark.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/unitary/quantum_chess/experiments/circuit_transform_benchmark.py
+++ b/unitary/quantum_chess/experiments/circuit_transform_benchmark.py
@@ -43,16 +43,17 @@ contains a bug and will never terminate on some of the circuits in that
 directory (https://github.com/quantumlib/ReCirq/issues/163).
 """
 
-import cirq
-import cirq_google as cg
 import cProfile
 import pstats
 import sys
+from timeit import default_timer as timer
+from typing import List
+
+import cirq
+import cirq_google as cg
+from cirq.contrib.qasm_import import circuit_from_qasm
 
 import unitary.quantum_chess.circuit_transformer as ct
-from cirq.contrib.qasm_import import circuit_from_qasm
-from typing import List
-from timeit import default_timer as timer
 
 
 def print_stats(time_sec: float, circuit: cirq.Circuit) -> None:

--- a/unitary/quantum_chess/experiments/circuit_transform_benchmark.py
+++ b/unitary/quantum_chess/experiments/circuit_transform_benchmark.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Benchmarking tool for logical-to-hardware circuit transformations.
+"""Benchmarking tool for logical-to-hardware circuit transformations.
 
 To run this:
   python unitary/quantum_chess/experiments/circuit_transform_benchmark.py \

--- a/unitary/quantum_chess/experiments/interactive_board.py
+++ b/unitary/quantum_chess/experiments/interactive_board.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/unitary/quantum_chess/experiments/interactive_board.py
+++ b/unitary/quantum_chess/experiments/interactive_board.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Interactive ascii-based quantum chess game.
+"""Interactive ascii-based quantum chess game.
 
 Run with:
 
@@ -50,6 +49,7 @@ Examples:
 
 The interactive board uses a simulator with an unconstrained device.
 """
+
 import argparse
 import sys
 

--- a/unitary/quantum_chess/initial_mapping_utils.py
+++ b/unitary/quantum_chess/initial_mapping_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google
+# Copyright 2021 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import math
 from collections import defaultdict, deque
 from typing import Deque, Dict, List, Optional, Tuple, Union, ValuesView

--- a/unitary/quantum_chess/initial_mapping_utils_test.py
+++ b/unitary/quantum_chess/initial_mapping_utils_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unitary/quantum_chess/initial_mapping_utils_test.py
+++ b/unitary/quantum_chess/initial_mapping_utils_test.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import pytest
+
 from collections import deque
 
 import cirq
 import cirq_google as cg
+import pytest
 
 import unitary.quantum_chess.initial_mapping_utils as imu
 

--- a/unitary/quantum_chess/mcpe_utils.py
+++ b/unitary/quantum_chess/mcpe_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google
+# Copyright 2021 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Utilities related to the maximum consecutive positive effect (mcpe) heuristic
 cost function.
 

--- a/unitary/quantum_chess/mcpe_utils.py
+++ b/unitary/quantum_chess/mcpe_utils.py
@@ -20,6 +20,7 @@ in the paper 'A Dynamic Look-Ahead Heuristic for the Qubit Mapping Problem of
 NISQ Computers'
 (https://ieeexplore.ieee.org/abstract/document/8976109).
 """
+
 from collections import defaultdict, deque
 from typing import Callable, Dict, Iterable, Set, Tuple
 

--- a/unitary/quantum_chess/mcpe_utils_test.py
+++ b/unitary/quantum_chess/mcpe_utils_test.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/unitary/quantum_chess/move.py
+++ b/unitary/quantum_chess/move.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unitary/quantum_chess/move.py
+++ b/unitary/quantum_chess/move.py
@@ -177,8 +177,7 @@ class Move:
         return self.measurement is not None
 
     def to_string(self, include_type=False) -> str:
-        """
-        Constructs the string representation of this move object.
+        """Constructs the string representation of this move object.
 
         By default, only returns the move source(s), target(s), and measurement
         if present.

--- a/unitary/quantum_chess/move.py
+++ b/unitary/quantum_chess/move.py
@@ -11,9 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from typing import Optional
+
 from unitary.quantum_chess import constants
 import unitary.quantum_chess.enums as enums
-from typing import Optional
 
 _ORD_A = ord("a")
 

--- a/unitary/quantum_chess/move_test.py
+++ b/unitary/quantum_chess/move_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from unitary.quantum_chess import constants
 from unitary.quantum_chess.move import Move
 import unitary.quantum_chess.enums as enums

--- a/unitary/quantum_chess/pauli_decomposition.py
+++ b/unitary/quantum_chess/pauli_decomposition.py
@@ -14,12 +14,14 @@
 """
 Utility functions used for decomposing the given measurement matrix into a PauliSum.
 """
-import cirq
+
 import itertools
 import functools
+from typing import List
+
+import cirq
 import numpy as np
 from scipy.linalg import kron
-from typing import List
 
 
 def kron_product(matrices: np.ndarray) -> np.ndarray:

--- a/unitary/quantum_chess/pauli_decomposition.py
+++ b/unitary/quantum_chess/pauli_decomposition.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google
+# Copyright 2021 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Utility functions used for decomposing the given measurement matrix into a PauliSum.
 """

--- a/unitary/quantum_chess/pauli_decomposition.py
+++ b/unitary/quantum_chess/pauli_decomposition.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Utility functions used for decomposing the given measurement matrix into a PauliSum.
-"""
+"""Utility functions used for decomposing the given measurement matrix into a PauliSum."""
 
 import itertools
 import functools

--- a/unitary/quantum_chess/pauli_decomposition_test.py
+++ b/unitary/quantum_chess/pauli_decomposition_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unitary/quantum_chess/pauli_decomposition_test.py
+++ b/unitary/quantum_chess/pauli_decomposition_test.py
@@ -11,10 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import pytest
+
+import re
+
 import cirq
 import numpy as np
-import re
+import pytest
 
 from unitary.quantum_chess.pauli_decomposition import pauli_decomposition
 

--- a/unitary/quantum_chess/puzzles_test.py
+++ b/unitary/quantum_chess/puzzles_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import pytest
 
 import unitary.quantum_chess.bit_utils as u

--- a/unitary/quantum_chess/quantum_board.py
+++ b/unitary/quantum_chess/quantum_board.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import time
 from collections import defaultdict
 from typing import Dict, List, Optional, Sequence, Set, Tuple

--- a/unitary/quantum_chess/quantum_board.py
+++ b/unitary/quantum_chess/quantum_board.py
@@ -942,7 +942,7 @@ class CirqBoard:
 
         if m.move_type == enums.MoveType.SPLIT_SLIDE:
             if not m.target2:
-                raise ValueError(f"Merge slide must have a second source move")
+                raise ValueError("Merge slide must have a second source move")
             tbit2 = square_to_bit(m.target2)
             tqubit2 = bit_to_qubit(tbit2)
 
@@ -1055,7 +1055,7 @@ class CirqBoard:
 
         if m.move_type == enums.MoveType.MERGE_SLIDE:
             if not m.source2:
-                raise ValueError(f"Merge slide must have a second source move")
+                raise ValueError("Merge slide must have a second source move")
             sbit2 = square_to_bit(m.source2)
             squbit2 = bit_to_qubit(sbit2)
 
@@ -1302,7 +1302,7 @@ class CirqBoard:
 
         if m.move_type == enums.MoveType.SPLIT_JUMP:
             if not m.target2:
-                raise ValueError(f"Split jumps must have a second target move")
+                raise ValueError("Split jumps must have a second target move")
             tbit2 = square_to_bit(m.target2)
             tqubit2 = bit_to_qubit(tbit2)
             is_basic_case = (
@@ -1322,7 +1322,7 @@ class CirqBoard:
 
         if m.move_type == enums.MoveType.MERGE_JUMP:
             if not m.source2:
-                raise ValueError(f"Merge jumps must have a second source move")
+                raise ValueError("Merge jumps must have a second source move")
             sbit2 = square_to_bit(m.source2)
             squbit2 = bit_to_qubit(sbit2)
             self.add_entangled(squbit, squbit2, tqubit)
@@ -1338,7 +1338,7 @@ class CirqBoard:
                 rook_sbit = square_to_bit("h8")
                 rook_tbit = square_to_bit("f8")
             else:
-                raise ValueError(f"Invalid kingside castling move")
+                raise ValueError("Invalid kingside castling move")
 
             return self._do_noncontrolled_castle(
                 m.move_variant, m.measurement, sbit, tbit, rook_sbit, rook_tbit
@@ -1355,7 +1355,7 @@ class CirqBoard:
                 rook_tbit = square_to_bit("d8")
                 b_bit = square_to_bit("b8")
             else:
-                raise ValueError(f"Invalid queenside castling move")
+                raise ValueError("Invalid queenside castling move")
 
             b_qubit = bit_to_qubit(b_bit)
             if b_qubit not in self.entangled_squares and not nth_bit_of(

--- a/unitary/quantum_chess/quantum_board_test.py
+++ b/unitary/quantum_chess/quantum_board_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 import random
 

--- a/unitary/quantum_chess/quantum_moves.py
+++ b/unitary/quantum_chess/quantum_moves.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Quantum Circuits for common quantum chess moves."""
 from typing import Sequence
 

--- a/unitary/quantum_chess/quantum_moves.py
+++ b/unitary/quantum_chess/quantum_moves.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Quantum Circuits for common quantum chess moves."""
+
 from typing import Sequence
 
 import cirq

--- a/unitary/quantum_chess/quantum_moves_test.py
+++ b/unitary/quantum_chess/quantum_moves_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 import cirq
 

--- a/unitary/quantum_chess/readout_tester.py
+++ b/unitary/quantum_chess/readout_tester.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-  Simple sanity test to test readout for device qubits.
-  This will test P11 and P00 for each qubit on the device.
+"""Simple sanity test to test readout for device qubits.
 
-  See https://www.twitch.tv/anna_chess/video/824369168
-  at 1h:17m to see how this can affect live demos.
+This will test P11 and P00 for each qubit on the device.
+
+See https://www.twitch.tv/anna_chess/video/824369168
+at 1h:17m to see how this can affect live demos.
 """
+
 from typing import Dict
 
 import cirq

--- a/unitary/quantum_chess/readout_tester.py
+++ b/unitary/quantum_chess/readout_tester.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 """
   Simple sanity test to test readout for device qubits.
   This will test P11 and P00 for each qubit on the device.

--- a/unitary/quantum_chess/readout_tester_test.py
+++ b/unitary/quantum_chess/readout_tester_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-#
+
 import cirq
 import cirq_google as cg
 

--- a/unitary/quantum_chess/swap_updater.py
+++ b/unitary/quantum_chess/swap_updater.py
@@ -18,6 +18,7 @@ Look-Ahead Heuristic for the Qubit Mapping Problem of NISQ Computers'
 
 This transforms circuits by adding additional SWAP gates to ensure that all operations are on adjacent qubits.
 """
+
 from collections import deque
 from typing import (
     Callable,

--- a/unitary/quantum_chess/swap_updater.py
+++ b/unitary/quantum_chess/swap_updater.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google
+# Copyright 2021 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Implementation of the swap update algorithm described in the paper 'A Dynamic
 Look-Ahead Heuristic for the Qubit Mapping Problem of NISQ Computers'
 (https://ieeexplore.ieee.org/abstract/document/8976109).

--- a/unitary/quantum_chess/swap_updater_test.py
+++ b/unitary/quantum_chess/swap_updater_test.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/unitary/quantum_chess/swap_updater_test.py
+++ b/unitary/quantum_chess/swap_updater_test.py
@@ -15,10 +15,10 @@
 import pytest
 import cirq
 import cirq_google as cg
+import numpy as np
 
 from unitary.quantum_chess.swap_updater import SwapUpdater, generate_decomposed_swap
 import unitary.quantum_chess.quantum_moves as qm
-import numpy as np
 
 # Logical qubits q0 - q5.
 q = list(cirq.NamedQubit(f"q{i}") for i in range(6))

--- a/unitary/quantum_chess/test_utils.py
+++ b/unitary/quantum_chess/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 The Unitary Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from collections import defaultdict
 from scipy.stats import chisquare
 


### PR DESCRIPTION
The previous CI pylint check was ineffective.
Run it for real here and clean up some of the exposed lint.

* Use the latest pylint-3 for the lint CI check
* Copy pylint_copyright_checker from Cirq and adjust the copyright text
* Use the same pylint configuration as in Cirq, apart from line length
* pylint - fix singleton-comparison
* pylint - fix docstring-first-line-empty
* pylint - fix f-string-without-interpolation
* pylint - fix wrong-or-nonexistent-copyright-notice
* pylint - fix wrong-import-order
* pylint - fix unused-import
* Temporarily disable rules that fail in pylint-3 and mark them with TODO comments

Partially fixes #210
