### PR TITLE
Pin versions & make other changes to CI workflows for best practices

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Python formatting
 
 on: [push, pull_request]
 

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -4,9 +4,11 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    name: Run black
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: psf/black@stable
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: psf/black@8a737e727ac5ab2f1d4cf5876720ed276dc8dc4b # stable
         with:
           src: "./unitary"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -2,6 +2,9 @@ name: Python formatting
 
 on: [push, pull_request]
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   lint:
     name: Run black

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push, pull_request]
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   pylint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -4,10 +4,11 @@ on: [push, pull_request]
 
 jobs:
   pylint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: '3.12'
           architecture: 'x64'

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,11 +13,15 @@
 # limitations under the License.
 
 name: Python package
+
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+
+# Declare default permissions as read only.
+permissions: read-all
 
 jobs:
   pytest:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,7 +22,8 @@ on:
 jobs:
   pytest:
     name: Pytest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     strategy:
       matrix:
         cirq-version:
@@ -30,8 +31,8 @@ jobs:
           - 'next'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: '3.12'
       - name: Install dependencies
@@ -57,10 +58,11 @@ jobs:
           UNITARY_CHESS_TEST_SEED=789 UNITARY_IMPORT_FAILSAFE=y pytest -v
   nbformat:
     name: Notebook formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: '3.12'
       - name: Doc check


### PR DESCRIPTION
Google's security practices for GitHub Actions states the following:

> When using a third-party action (one not hosted in a [Google-managed org](http://go/github/orgs)), a fixed version of the action MUST be used by [specifying a specific commit](https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsuses), rather than a branch like "main", or a tagged release, which can be overwritten by any maintainer of the action.

This commit adds sha hash numbers to all `uses:` directives that didn't have one already. This was done by running the tool [frizbee](https://github.com/stacklok/frizbee?README) over the files.

In addition, it does the following other best-practices changes:

- pin versions of runners instead of using *-latest
- set default permissions for workflow
- set timeouts on jobs, to prevent running for 6 hrs (the default) in case of hangs or loops

This should also fix the following code scanning alerts:

- https://github.com/quantumlib/unitary/security/code-scanning/1
- https://github.com/quantumlib/unitary/security/code-scanning/2
- https://github.com/quantumlib/unitary/security/code-scanning/3
- https://github.com/quantumlib/unitary/security/code-scanning/4
