### PR TITLE
Fix tiny warnings from shellcheck

### DIFF
--- a/dev_tools/nbfmt
+++ b/dev_tools/nbfmt
@@ -15,8 +15,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd "$(git rev-parse --show-toplevel)"
+cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" || exit
+cd "$(git rev-parse --show-toplevel)" || exit
 
 # Check if cirq/check/nbformat exists, if not grab it.
 if [[ ! -f dev_tools/nbformat ]]; then

--- a/dev_tools/pylint
+++ b/dev_tools/pylint
@@ -8,8 +8,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+cd "$(dirname "${BASH_SOURCE[0]}")" || exit
+cd "$(git rev-parse --show-toplevel)" || exit
 
 # Add dev_tools to $PYTHONPATH so that pylint can find custom checkers
 env PYTHONPATH=dev_tools pylint --jobs=0 --rcfile=dev_tools/.pylintrc "$@" .


### PR DESCRIPTION
This fixes minor warnings from shellcheck in two of the shell scripts in dev_tools/.