### PR TITLE
Add problem matchers

### DIFF
--- a/.github/problem-matchers/README.md
+++ b/.github/problem-matchers/README.md
@@ -1,0 +1,25 @@
+# Problem Matchers
+
+GitHub [Problem
+Matchers](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md)
+are a mechanism that enable workflow steps to scan the outputs of GitHub
+Actions for regex patterns and automatically write annotations in the workflow
+summary page. Using Problem Matchers allows information to be displayed more
+prominently in the GitHub user interface.
+
+This directory contains Problem Matchers used by the GitHub Actions workflows
+in the [`workflows`](./workflows) subdirectory.
+
+The following problem matcher JSON file for Pylint was copied from the [Home
+Assistant](https://github.com/home-assistant/core) project on GitHub. The Home
+Assistant project is licensed under the Apache 2.0 open-source license. The
+versions of the file at the time it was copied was 2025.1.2.
+
+- [`pylint.json`](https://github.com/home-assistant/core/blob/dev/.github/workflows/matchers/pylint.json)
+
+The following problem matcher for Black came from a fork of the
+[MLflow](https://github.com/mlflow/mlflow) project by user Sumanth077 on
+GitHub. The MLflow project is licensed under the Apache 2.0 open-source
+license. The version of the file copied was dated 2022-05-29.
+
+- [`black.json`](https://github.com/Sumanth077/mlflow/blob/problem-matcher-for-black/.github/workflows/matchers/black.json)

--- a/.github/problem-matchers/black.json
+++ b/.github/problem-matchers/black.json
@@ -1,0 +1,15 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "black",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^(would reformat) (.+)$",
+          "file": 2,
+          "message": 1
+        }
+      ]
+    }
+  ]
+}

--- a/.github/problem-matchers/pylint.json
+++ b/.github/problem-matchers/pylint.json
@@ -1,0 +1,32 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "pylint-error",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^(.+):(\\d+):(\\d+):\\s(([EF]\\d{4}):\\s.+)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    },
+    {
+      "owner": "pylint-warning",
+      "severity": "warning",
+      "pattern": [
+        {
+          "regexp": "^(.+):(\\d+):(\\d+):\\s(([CRW]\\d{4}):\\s.+)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -12,6 +12,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Set up problem matcher for Black output
+        run: echo '::add-matcher::.github/problem-matchers/black.json'
       - uses: psf/black@8a737e727ac5ab2f1d4cf5876720ed276dc8dc4b # stable
         with:
           src: "./unitary"

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -19,5 +19,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pylint
+      - name: Set up problem matcher for Pylint output
+        run: echo '::add-matcher::.github/problem-matchers/pylint.json'
       - name: Pylint check
         run: dev_tools/pylint


### PR DESCRIPTION
GitHub [Problem Matchers](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md) are a mechanism that enable workflow steps to scan the outputs of GitHub Actions for regex patterns and automatically write annotations in the workflow summary page. Using Problem Matchers allows information to be displayed more prominently in the GitHub user interface.

This add problem matchers for Pylint and Black output. More problem matchers can be added in the future as more checks are added to the CI workflows.
