### PR TITLE
Constrain pip to install NumPy < 2.0

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -42,6 +42,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          echo 'numpy<2.0.0' > constraint.txt
+          export PIP_CONSTRAINT=constraint.txt
           python dev_tools/write-ci-requirements.py --relative-cirq-version=${{ matrix.cirq-version }} --all-extras
           pip install -r ci-requirements.txt
           pip install --no-deps -e .


### PR DESCRIPTION

The latest Cirq work with NumPy 2.0 and no longer constrains the NumPy version like it did before, but Unitary does not seem to work with NumPy 2, so we need to tell pip not to install it.