### PR TITLE
Add supporting links for ISWAP and other gates

### DIFF
--- a/docs/quantum_chess/concepts.ipynb
+++ b/docs/quantum_chess/concepts.ipynb
@@ -72,7 +72,7 @@
     "\n",
     "This tutorial assumes basic knowledge of the following:\n",
     "\n",
-    "*   Basic quantum computing principles, specifically, what unitary matrices are, and what an $\\text{iSWAP}$ (and $\\sqrt{\\text{iSWAP}}$ gate is)\n",
+    "*   Basic quantum computing principles, specifically, what unitary matrices are, and what an $\\text{iSWAP}$ (and $\\sqrt{\\text{iSWAP}}$ gate is).  See [Quantum Logic Gates](https://en.wikipedia.org/wiki/Quantum_logic_gate) for common quantum gates or [iSWAP and others](https://en.wikipedia.org/wiki/List_of_quantum_logic_gates#Two-qubit_interaction_gates) for details on $\\sqrt{\\text{iSWAP}}$.\n",
     "*   The basic movement rules of [Chess](https://en.wikipedia.org/wiki/Chess#Movement) and the [Algebraic notation](https://en.wikipedia.org/wiki/Algebraic_notation_(chess)) method of naming chess squares and moves.\n",
     "\n",
     "\n",


### PR DESCRIPTION
- Long-standing bug from a feedback about missing links on what ISWAP and sqrt-ISWAP gates were for those that were unfamiliar but interested in quantum chess.